### PR TITLE
Fix Dependabot PRs failing required checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
       interval: monthly
     commit-message:
       prefix: "ci"
+    groups:
+      # init and analyze in codeql.yml must run the same CodeQL Action
+      # version -- a mismatch fails the job outright ("Loaded a configuration
+      # file for version X, but running version Y"). Dependabot otherwise
+      # treats each `uses:` subpath as an independent dependency and opens a
+      # separate PR per one, which is exactly how that mismatch happened the
+      # first time (PRs bumping init and analyze arrived separately).
+      # upload-sarif is unaffected by the pairing but shares the same repo
+      # and version stream, so it rides along rather than drifting.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: pip
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,15 @@ jobs:
           fi
 
       - name: Analyze with SonarQube Cloud
-        if: matrix.python-version == '3.12'
+        # Skipped for Dependabot: GitHub keeps Dependabot-triggered runs on a
+        # separate secret store from ordinary Actions secrets (same reasoning
+        # as the read-only GITHUB_TOKEN noted in dependabot-auto-merge.yml),
+        # so SONAR_TOKEN is empty here regardless of what's configured in repo
+        # settings. Sonar analyses this project's own source, not a
+        # dependency's, so a version-bump PR has nothing for it to find
+        # anyway -- unlike the read-only token, this isn't worth granting
+        # Dependabot secret access to route around.
+        if: matrix.python-version == '3.12' && github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2  # v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -29,14 +28,23 @@ jobs:
   analyze:
     name: CodeQL
     runs-on: ubuntu-latest
+    # Job-scoped rather than workflow-scoped, even though there is only one
+    # job: OSSF Scorecard's Token-Permissions check specifically rewards the
+    # narrower form.
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3.37.6
+      # init and analyze must stay on the same CodeQL Action version, or the
+      # job fails outright with a config/runtime version mismatch. Grouped in
+      # dependabot.yml so a bump always lands both together.
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: python
           build-mode: none
 
-      - uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3.37.6
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           category: "/language:python"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,12 +14,8 @@ name: Dependabot auto-merge
 
 on: pull_request
 
-# Least privilege: enough to approve and queue a merge, nothing else. Note that
-# workflows triggered by Dependabot get a read-only token unless the permissions
-# are granted explicitly here.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
@@ -27,6 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     # Anyone can open a pull request. Only Dependabot's get this treatment.
     if: github.actor == 'dependabot[bot]'
+    # Least privilege: enough to approve and queue a merge, nothing else. Note
+    # that workflows triggered by Dependabot get a read-only token unless the
+    # permissions are granted explicitly here. Job-scoped rather than
+    # workflow-scoped, even though there is only one job: OSSF Scorecard's
+    # Token-Permissions check specifically rewards the narrower form.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # This action is the guard's own dependency, which makes it the one bump
       # in this repository worth reading rather than waving through: a change to

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,8 +31,8 @@ jobs:
           mkdir -p _site/assets
           cp -R site/. _site/
           cp docs/images/unifi-map-promo.gif _site/assets/
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: _site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
## Summary
Every open Dependabot PR (#6-#10) was failing `Python 3.12`, a required status check, blocking `dependabot-auto-merge.yml` entirely. Two distinct bugs, both fixed here:

- **SONAR_TOKEN unavailable to Dependabot runs.** GitHub keeps a separate "Dependabot secrets" store from ordinary Actions secrets; a Dependabot-triggered `pull_request` run never sees the latter (same restriction `dependabot-auto-merge.yml` already documents for `GITHUB_TOKEN`). The Sonar step 403s and fails the job. Fixed by skipping that step for `dependabot[bot]` -- it analyses this project's own source, not a dependency's, so a version bump has nothing for it to find anyway.
- **codeql.yml's init/analyze version mismatch.** Dependabot bumped `init` (#7) and `analyze` (#9) to v4.37.6 in two separate PRs, since it tracks each `uses:` subpath independently. Only one landing at a time breaks the pairing (`Loaded a configuration file for version '4.37.6', but running version '3.37.6'`). Synced both by hand and added a `dependabot.yml` group so `init`/`analyze`/`upload-sarif` always move together from now on.

Also included, two Scorecard fixes flagged earlier in the day but not actually applied before now: `pages.yml`'s two actions were still tag-pinned instead of SHA-pinned, and `codeql.yml`/`dependabot-auto-merge.yml` granted their write permissions at workflow level instead of job level (Scorecard's Token-Permissions check rewards the narrower form).

## Follow-up (not in this PR)
Once this merges, PRs #6, #8, #10 should pass on rebase and auto-merge on their own. #7 and #9 are superseded by the manual sync here and should be closed once this lands.

## Test plan
- [x] `make check` passes locally
- [x] All five touched YAML files parse cleanly
- [ ] Watch this PR's own required checks (the real proof that the Sonar skip and codeql-action sync work)