### PR TITLE
Add ClusterFuzzLite fuzzing for support.py's archive parser

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -8,13 +8,21 @@
 # anywhere -- it exists for the minutes this job runs and is discarded after.
 FROM gcr.io/oss-fuzz-base/base-builder-python
 
-RUN pip3 install --only-binary=:all: atheris==3.1.0
+# Not the latest (3.1.0): oss-fuzz-base's Python/platform combination has no
+# prebuilt wheel for it, and --only-binary=:all: refuses to fall back to a
+# source build. 3.0.0 is confirmed available for this image.
+RUN pip3 install --only-binary=:all: atheris==3.0.0
 
-# Scoped by the repo root .dockerignore: excludes .git, local caches and venvs
-# so a contributor's own build never ships local state (a cache/ directory in
-# particular can hold a real network inventory; see CLAUDE.md's data-hygiene
-# section) into the image just because this copies recursively.
-COPY . $SRC/unifi-map
+# Named explicitly rather than `COPY . $SRC/unifi-map`: an allowlist can only
+# ever copy what it names, where a blocklist (the repo root .dockerignore,
+# kept anyway as a second layer) has to be remembered every time something
+# new needs excluding. A contributor's local cache/ in particular can hold a
+# real network's MAC/hostname/IP inventory -- see CLAUDE.md's data-hygiene
+# section -- and has no business anywhere near this build.
+COPY pyproject.toml LICENSE unifi-map.1 $SRC/unifi-map/
+COPY src $SRC/unifi-map/src
+COPY requirements $SRC/unifi-map/requirements
+COPY .clusterfuzzlite $SRC/unifi-map/.clusterfuzzlite
 COPY .clusterfuzzlite/build.sh $SRC/
 
 WORKDIR $SRC/unifi-map

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,11 @@
+# Built by ClusterFuzzLite's own GitHub Actions (build_fuzzers), not by this
+# repo's ci.yml -- oss-fuzz-base is Google's image and is not something we
+# maintain or pin further here; ClusterFuzzLite's own actions choose the tag.
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN pip3 install atheris
+
+COPY . $SRC/unifi-map
+COPY .clusterfuzzlite/build.sh $SRC/
+
+WORKDIR $SRC/unifi-map

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,10 +1,19 @@
 # Built by ClusterFuzzLite's own GitHub Actions (build_fuzzers), not by this
 # repo's ci.yml -- oss-fuzz-base is Google's image and is not something we
 # maintain or pin further here; ClusterFuzzLite's own actions choose the tag.
+#
+# Runs as root, flagged by static analysis and left as-is: oss-fuzz-base's own
+# build tooling (compile_python_fuzzer and friends) assumes it, this build
+# never runs as a long-lived service, and the image is never published
+# anywhere -- it exists for the minutes this job runs and is discarded after.
 FROM gcr.io/oss-fuzz-base/base-builder-python
 
-RUN pip3 install atheris
+RUN pip3 install --only-binary=:all: atheris==3.1.0
 
+# Scoped by the repo root .dockerignore: excludes .git, local caches and venvs
+# so a contributor's own build never ships local state (a cache/ directory in
+# particular can hold a real network inventory; see CLAUDE.md's data-hygiene
+# section) into the image just because this copies recursively.
 COPY . $SRC/unifi-map
 COPY .clusterfuzzlite/build.sh $SRC/
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+# Run by ClusterFuzzLite's build_fuzzers action inside the Dockerfile's image.
+# $SRC and $OUT are set by the oss-fuzz-base image, not by us.
+
+cd "$SRC/unifi-map"
+pip3 install .
+
+cp .clusterfuzzlite/fuzz_support_archive.py "$SRC/"
+compile_python_fuzzer "$SRC/fuzz_support_archive.py"
+
+# See make_seed_corpus.py for why a seed matters here: a blind mutation
+# engine essentially never produces a valid gzip header on its own.
+python3 .clusterfuzzlite/make_seed_corpus.py "$OUT/fuzz_support_archive_seed_corpus.zip"

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -3,7 +3,17 @@
 # $SRC and $OUT are set by the oss-fuzz-base image, not by us.
 
 cd "$SRC/unifi-map"
-pip3 install .
+
+# Same hashed lock ci.yml installs from (KAN-191), reused rather than
+# maintaining a second one just for this build. It covers more than this
+# build strictly needs (the dev and svg extras, plus pip-audit), which costs
+# a slightly heavier image and nothing else, and keeps one lock file for
+# Dependabot to track instead of two. --require-hashes rejects an editable
+# install outright regardless of what else is on the command line, so the
+# local package is a second, unhashed --no-deps install, exactly like
+# ci.yml's own "Install" step.
+pip3 install --only-binary=:all: --require-hashes -r requirements/ci.txt
+pip3 install --no-deps --only-binary=:all: .
 
 cp .clusterfuzzlite/fuzz_support_archive.py "$SRC/"
 compile_python_fuzzer "$SRC/fuzz_support_archive.py"

--- a/.clusterfuzzlite/fuzz_support_archive.py
+++ b/.clusterfuzzlite/fuzz_support_archive.py
@@ -1,0 +1,43 @@
+"""ClusterFuzzLite harness for support.py's archive parser.
+
+Feeds candidate bytes through `load_support_file`, the same entry point
+`--support-file` uses. A support file is attacker-supplied by this project's
+own threat model (see CLAUDE.md's "Support files are attacker-supplied"
+section), so this is the one parser that already assumes hostile input; the
+harness exists to find the cases the handwritten adversarial tests in
+tests/test_support.py did not think of, not to duplicate them.
+
+`load_support_file` takes a path rather than a file object -- it opens the
+archive itself via `tarfile.open(path, "r|gz")` -- so each iteration writes
+the candidate bytes to a temporary file rather than fuzzing in memory.
+`SupportFileError` is the library's own "this is not a valid archive" signal
+and is swallowed; anything else propagating out of a real support-file path
+is a bug this harness exists to catch, not something to suppress here.
+"""
+
+import contextlib
+import sys
+import tempfile
+from pathlib import Path
+
+import atheris
+
+with atheris.instrument_imports():
+    from unifi_map.support import SupportFileError, load_support_file
+
+
+def TestOneInput(data: bytes) -> None:
+    with tempfile.NamedTemporaryFile(suffix=".tgz") as handle:
+        handle.write(data)
+        handle.flush()
+        with contextlib.suppress(SupportFileError):
+            load_support_file(Path(handle.name))
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/.clusterfuzzlite/make_seed_corpus.py
+++ b/.clusterfuzzlite/make_seed_corpus.py
@@ -1,0 +1,61 @@
+"""Builds a tiny valid support-file archive as a fuzzing seed.
+
+A pure-random mutation engine starting from nothing would spend nearly all of
+its budget failing the gzip magic-byte check and never reach the tar-member or
+JSON-parsing logic underneath. One small, valid, structurally-plausible
+archive is enough to get the fuzzer past that gate so it can start mutating
+toward interesting cases instead of away from them.
+
+Deliberately minimal rather than a copy of tests/test_support.py's richer
+fixture: a seed only needs to be valid enough to reach the code paths worth
+fuzzing, and a smaller seed mutates and executes faster. Content follows this
+project's own rule for non-identifying fixtures (see CONTRIBUTING.md):
+locally-administered MAC, no real hostnames or subnets.
+
+Standalone rather than importing from tests/, which is not part of the
+installed package and is a fragile thing for build-time fuzzing
+infrastructure to depend on.
+"""
+
+import io
+import json
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+_ROOT = "support-fuzz-seed"
+
+_DEVICES = [
+    {"default": [{"mac": "02:00:00:00:00:01", "sysid": "1", "model": "USW", "network_table": []}]}
+]
+_TOPOLOGY = {"default": {"data": [{"vertexType": "DEVICE", "mac": "02:00:00:00:00:01"}]}}
+_INFRASTRUCTURE = {"default": {}}
+
+_MEMBERS = {
+    "unifi/devices.json": json.dumps(_DEVICES).encode(),
+    "unifi/topology.json": json.dumps(_TOPOLOGY).encode(),
+    "unifi/infrastructure.json": json.dumps(_INFRASTRUCTURE).encode(),
+    "system/run/dnsmasq.lease": b"",
+    "system/network/ip-neigh": b"",
+}
+
+
+def _build_archive() -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, payload in _MEMBERS.items():
+            info = tarfile.TarInfo(f"{_ROOT}/{name}")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return buffer.getvalue()
+
+
+def main() -> None:
+    out_zip = Path(sys.argv[1])
+    with zipfile.ZipFile(out_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("support-seed.tgz", _build_archive())
+
+
+if __name__ == "__main__":
+    main()

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: python

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Scopes what .clusterfuzzlite/Dockerfile's `COPY . $SRC/unifi-map` actually
+# ships into the fuzzing build image. Mirrors .gitignore's reasoning: cache*/
+# can hold a real network's MAC, hostname and IP inventory (see CLAUDE.md's
+# data-hygiene section), and none of this is needed to build or run a fuzzer
+# anyway.
+.git/
+.env
+*.env
+
+cache*/
+out*/
+
+dist/
+build/
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.coverage
+coverage.xml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
-# Scopes what .clusterfuzzlite/Dockerfile's `COPY . $SRC/unifi-map` actually
-# ships into the fuzzing build image. Mirrors .gitignore's reasoning: cache*/
-# can hold a real network's MAC, hostname and IP inventory (see CLAUDE.md's
-# data-hygiene section), and none of this is needed to build or run a fuzzer
-# anyway.
+# Second layer, not the primary guard: .clusterfuzzlite/Dockerfile names
+# exactly what it copies rather than copying `.` recursively, so none of this
+# should ever reach the build context in the first place. Kept anyway. Mirrors
+# .gitignore's reasoning: cache*/ can hold a real network's MAC, hostname and
+# IP inventory (see CLAUDE.md's data-hygiene section).
 .git/
 .env
 *.env

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,7 +22,8 @@ on:
       - ".github/workflows/cifuzz.yml"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: cifuzz-${{ github.ref }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,58 @@
+name: ClusterFuzzLite
+
+# Fuzzes support.py's archive parser, the one piece of code that already
+# treats its input as hostile by this project's own threat model (support
+# files are attacker-supplied; see CLAUDE.md). Self-hosted in this repo's own
+# CI rather than an OSS-Fuzz application: no external repo to keep in sync, no
+# review/acceptance process, and it still satisfies OSSF Scorecard's Fuzzing
+# check the same way OSS-Fuzz integration would. KAN-194.
+#
+# PR-triggered only, "code-change" mode, for now. A scheduled/batch job would
+# fuzz for longer and catch a regression even without a triggering PR, but
+# needs cross-run corpus persistence in cloud storage, which is real
+# additional infrastructure (a GCP project, a service account, a bucket) this
+# project does not otherwise depend on. Deliberately not added yet.
+
+on:
+  pull_request:
+    paths:
+      - "src/unifi_map/support.py"
+      - "src/unifi_map/client.py"
+      - ".clusterfuzzlite/**"
+      - ".github/workflows/cifuzz.yml"
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: cifuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: PR fuzzing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: python
+
+      - name: Run fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          fuzz-seconds: 300
+          mode: "code-change"
+          sanitizer: address
+          output-sarif: true
+
+      - name: Upload crash artifacts
+        if: failure() && steps.build.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cifuzz-crash-artifacts
+          path: ./out/artifacts
+          retention-days: 5

--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **677 automated tests**, none of which touch the network. They cover the
+- **678 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1714,23 +1714,37 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
 
   **SonarQube's own quality gate caught four real issues in this
   infrastructure on the same PR**, worth listing because none were
-  hypothetical: the Dockerfile's `COPY . $SRC/unifi-map` had no
-  `.dockerignore` scoping it, so a contributor's local `cache/` (a real
-  network's MAC/hostname/IP inventory, see the data-hygiene section) would
-  have been copied into the build context on a local build; both `pip3
-  install` calls (the Dockerfile's `atheris` and `build.sh`'s installing this
-  project) had neither a pinned version nor `--only-binary=:all:`; and
-  `cifuzz.yml`'s top-level `permissions: read-all` should have been the
-  explicit `contents: read` form, same as everywhere else in this repo's
-  workflows. Fixed: a root `.dockerignore` mirroring `.gitignore`'s
-  exclusions, `atheris==3.1.0` pinned with `--only-binary=:all:`, `build.sh`
-  installing from `requirements/ci.txt` with `--require-hashes` (the same
-  lock `ci.yml` uses, reused rather than duplicated) and the local package
-  `--no-deps`, and the explicit permissions form. One finding was left open
-  on purpose: the base image runs as root, flagged as a MINOR finding and
-  left with a comment explaining why, since `oss-fuzz-base`'s own build
-  tooling assumes it and the image is never published anywhere -- it exists
-  for the minutes this job runs and is discarded after.
+  hypothetical: the Dockerfile's `COPY . $SRC/unifi-map` copied the whole
+  repo, so a contributor's local `cache/` (a real network's MAC/hostname/IP
+  inventory, see the data-hygiene section) would have been copied into the
+  build context on a local build; both `pip3 install` calls (the Dockerfile's
+  `atheris` and `build.sh`'s installing this project) had neither a pinned
+  version nor `--only-binary=:all:`; and `cifuzz.yml`'s top-level
+  `permissions: read-all` should have been the explicit `contents: read`
+  form, same as everywhere else in this repo's workflows.
+
+  Fixed: the Dockerfile now names exactly what it copies
+  (`pyproject.toml LICENSE unifi-map.1`, `src`, `requirements`,
+  `.clusterfuzzlite`) instead of copying `.` recursively -- an allowlist can
+  only ever copy what it names, which is a stronger fix than a
+  `.dockerignore` blocklist that has to be remembered every time something
+  new needs excluding, and was tried first: the rule flags any recursive
+  `COPY .` syntactically and does not check whether a `.dockerignore` scopes
+  it, so it stayed open even after one was added. The root `.dockerignore`
+  is kept anyway as a second layer, in case a future edit reintroduces a
+  broad `COPY`. Also fixed: `build.sh` installing from `requirements/ci.txt`
+  with `--require-hashes` (the same lock `ci.yml` uses, reused rather than
+  duplicated) and the local package `--no-deps`, and the explicit
+  permissions form. `atheris` is pinned to `3.0.0` rather than the newest
+  release (`3.1.0`) for an unrelated reason found while fixing this:
+  `oss-fuzz-base`'s Python/platform combination has no prebuilt wheel for
+  `3.1.0`, and `--only-binary=:all:` refuses to fall back to a source build.
+
+  One finding was left open on purpose: the base image runs as root, flagged
+  as a MINOR finding and left with a comment explaining why, since
+  `oss-fuzz-base`'s own build tooling assumes it and the image is never
+  published anywhere -- it exists for the minutes this job runs and is
+  discarded after.
 - **SonarQube Cloud runs inside `ci.yml`'s test job, not as Automatic
   Analysis.** `sonar-project.properties` says why in its first line: only an
   explicit analysis can import Python coverage, and Automatic Analysis was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1646,6 +1646,26 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
   (libFuzzer via Atheris) inside this repo's own GitHub Actions and satisfies
   the same Scorecard check.
 
+  **It found a real crash within seconds of its first real run**, on the PR
+  that added it, which is the argument for building this in the first place
+  rather than a hypothetical. `_read_members` caught `tarfile.TarError` and
+  `OSError` around the archive-reading block, but tarfile's streaming
+  (`"r|gz"`) mode hand-rolls its own gzip-header reader rather than delegating
+  to the `gzip` module, and a stream that ends mid-header raises a bare
+  `TypeError` from deep inside `tarfile.py` (`ord(self.__read(1))` against an
+  empty read) that neither except clause caught. A support file is
+  attacker-supplied by this project's own threat model, so a truncated or
+  corrupted archive used to crash the whole `--support-file` run with an
+  unhandled `TypeError` instead of a clean `SupportFileError`. Fixed with a
+  final `except Exception` around the same block, re-raising
+  `SupportFileError` first so it passes through unchanged rather than getting
+  double-wrapped: everything else reaching that point is tarfile or gzip
+  decoding attacker-controlled bytes, not this function's own logic, so the
+  same "not a readable archive" framing applies regardless of the exception's
+  exact type. `tests/test_support.py` pins it with a hand-constructed 8-byte
+  truncated header rather than the fuzzer's own opaque bytes, mutation-tested
+  by confirming it fails red against the code before this fix.
+
   **Target: `support.py`'s archive parser, and nothing else yet.** It is the
   one piece of code this project already treats as hostile input by its own
   threat model -- "Support files are attacker-supplied, and the parsing
@@ -1691,6 +1711,26 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
   same reason as the coverage exclusion below it: real maintained Python worth
   analyzing, but not reachable from pytest, so counting it toward coverage
   would only measure the gap rather than anything meaningful.
+
+  **SonarQube's own quality gate caught four real issues in this
+  infrastructure on the same PR**, worth listing because none were
+  hypothetical: the Dockerfile's `COPY . $SRC/unifi-map` had no
+  `.dockerignore` scoping it, so a contributor's local `cache/` (a real
+  network's MAC/hostname/IP inventory, see the data-hygiene section) would
+  have been copied into the build context on a local build; both `pip3
+  install` calls (the Dockerfile's `atheris` and `build.sh`'s installing this
+  project) had neither a pinned version nor `--only-binary=:all:`; and
+  `cifuzz.yml`'s top-level `permissions: read-all` should have been the
+  explicit `contents: read` form, same as everywhere else in this repo's
+  workflows. Fixed: a root `.dockerignore` mirroring `.gitignore`'s
+  exclusions, `atheris==3.1.0` pinned with `--only-binary=:all:`, `build.sh`
+  installing from `requirements/ci.txt` with `--require-hashes` (the same
+  lock `ci.yml` uses, reused rather than duplicated) and the local package
+  `--no-deps`, and the explicit permissions form. One finding was left open
+  on purpose: the base image runs as root, flagged as a MINOR finding and
+  left with a comment explaining why, since `oss-fuzz-base`'s own build
+  tooling assumes it and the image is never published anywhere -- it exists
+  for the minutes this job runs and is discarded after.
 - **SonarQube Cloud runs inside `ci.yml`'s test job, not as Automatic
   Analysis.** `sonar-project.properties` says why in its first line: only an
   explicit analysis can import Python coverage, and Automatic Analysis was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1628,16 +1628,69 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
   comment. A tag is mutable, so whoever controls the action decides what runs.
   Dependabot advances the pins and preserves the SHA form; it does not revert
   them to tags.
-- **Four workflows, and they answer different questions.** `ci.yml` is
+- **Five workflows, and they answer different questions.** `ci.yml` is
   correctness and quality, `codeql.yml` is security data flow,
   `scorecard.yml` is supply-chain hygiene of the repository itself (branch
-  protection, pinned dependencies, whether a security policy exists), and
-  `dependabot-auto-merge.yml` is bookkeeping. Do not consolidate them:
-  `codeql.yml` and `scorecard.yml` are the only two granted
-  `security-events: write`, each to upload its own SARIF to code scanning,
-  and that scoping is the point. (`pages.yml` also exists, for the project
-  site; it isn't part of this group because it answers neither a quality nor
-  a security question.)
+  protection, pinned dependencies, whether a security policy exists),
+  `cifuzz.yml` is fuzzing (KAN-194, see below), and `dependabot-auto-merge.yml`
+  is bookkeeping. Do not consolidate them: `codeql.yml` and `scorecard.yml`
+  are the only two granted `security-events: write`, each to upload its own
+  SARIF to code scanning, and that scoping is the point. (`pages.yml` also
+  exists, for the project site; it isn't part of this group because it
+  answers neither a quality nor a security question.)
+
+- **Fuzzing: `cifuzz.yml`, ClusterFuzzLite, self-hosted rather than an OSS-Fuzz
+  application.** Prompted by OSSF Scorecard scoring Fuzzing at 0. OSS-Fuzz
+  proper means a second repository (`google/oss-fuzz`) to keep in sync and an
+  application/review step; ClusterFuzzLite runs the same fuzzing engine
+  (libFuzzer via Atheris) inside this repo's own GitHub Actions and satisfies
+  the same Scorecard check.
+
+  **Target: `support.py`'s archive parser, and nothing else yet.** It is the
+  one piece of code this project already treats as hostile input by its own
+  threat model -- "Support files are attacker-supplied, and the parsing
+  assumes it" is a whole section above -- and fuzzing it exercises both layers
+  in one harness: the tar/gzip-format layer (`_read_members`'s entry, size and
+  total caps) and the JSON/data-shape layer underneath (`_load_json` and
+  everything that trusts the parsed shape: `_device_sites`, `_pick_site`,
+  `_networkconf`, `_parse_leases`, `_parse_neighbours`, `_dpi_hosts`,
+  `_client_active`). `client.py` and `model.py` are in the trigger's path
+  filter because `Snapshot`'s shape is the one thing `support.py` imports, but
+  nothing there is fuzzed directly.
+
+  **The harness writes each candidate to a temp file rather than fuzzing in
+  memory.** `load_support_file(path: Path, ...)` opens the archive itself via
+  `tarfile.open(path, "r|gz")`; there is no file-object entry point to call
+  instead. `SupportFileError` is swallowed as the library's own "not a valid
+  archive" signal; anything else escaping is a real finding, not something to
+  catch and hide.
+
+  **The seed corpus is generated at build time (`make_seed_corpus.py`), not
+  committed.** A blind mutation engine starting from nothing spends nearly all
+  its budget failing the gzip magic-byte check and never reaches the
+  interesting logic underneath; one small valid archive gets it past that gate
+  for free. Generating it at build time rather than committing a binary `.tgz`
+  keeps `Binary-Artifacts` at 10 and matches this project's standing rule
+  against committing generated/fetched binaries -- the same reasoning that
+  keeps Ubiquiti's artwork out of the repo applies here even though this
+  binary is entirely ours. The seed is deliberately smaller and less realistic
+  than `tests/test_support.py`'s `support_archive` fixture: it only needs to
+  be valid enough to reach the code worth fuzzing, and a smaller seed mutates
+  and executes faster. Standalone rather than importing the test fixture,
+  since `tests/` is not part of the installed package and is a fragile thing
+  for build-time infrastructure to depend on.
+
+  **PR-triggered only, `code-change` mode, for now.** A scheduled/batch job
+  would fuzz for longer and catch a regression even without a triggering PR,
+  but needs cross-run corpus persistence in cloud storage -- a GCP project, a
+  service account, a bucket -- which is real infrastructure this project does
+  not otherwise depend on. Deliberately not added yet; revisit if the PR-mode
+  run ever finds something a batch run would have caught sooner.
+
+  `.clusterfuzzlite/*.py` is in `sonar.sources` alongside `scripts/**` for the
+  same reason as the coverage exclusion below it: real maintained Python worth
+  analyzing, but not reachable from pytest, so counting it toward coverage
+  would only measure the gap rather than anything meaningful.
 - **SonarQube Cloud runs inside `ci.yml`'s test job, not as Automatic
   Analysis.** `sonar-project.properties` says why in its first line: only an
   explicit analysis can import Python coverage, and Automatic Analysis was

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,10 +2,12 @@
 # Automatic Analysis: only an explicit analysis can import Python coverage.
 sonar.projectKey=gitkodak_unifi-map
 sonar.organization=gitkodak
-sonar.sources=src,scripts,.github,pyproject.toml
+sonar.sources=src,scripts,.clusterfuzzlite,.github,pyproject.toml
 sonar.tests=tests
 sonar.python.version=3.11,3.12,3.13
 sonar.python.coverage.reportPaths=coverage.xml
 # The report deliberately measures the installable package; repository utility
-# scripts are still analyzed, but do not distort the application's coverage.
-sonar.coverage.exclusions=scripts/**
+# scripts -- and the fuzzing harness/build config, same category -- are still
+# analyzed, but do not distort the application's coverage. Neither runs under
+# pytest, so without this every line in both would show as uncovered.
+sonar.coverage.exclusions=scripts/**,.clusterfuzzlite/**

--- a/src/unifi_map/support.py
+++ b/src/unifi_map/support.py
@@ -278,10 +278,26 @@ def _read_members(
                             f"Support file members exceed {max_total} bytes in total. "
                             "Raise it with --support-max-total if that is legitimate."
                         )
+    except SupportFileError:
+        raise
     except tarfile.TarError as exc:
         raise SupportFileError(f"{path} is not a readable gzipped tar archive: {exc}") from exc
     except OSError as exc:
         raise SupportFileError(f"Could not read {path}: {exc}") from exc
+    except Exception as exc:
+        # tarfile's streaming ("r|gz") mode hand-rolls its own gzip-header
+        # reader rather than delegating to the gzip module, and does not wrap
+        # every way that can fail in TarError: a stream that ends mid-header
+        # raises a bare TypeError from deep inside tarfile.py
+        # (`ord(self.__read(1))` against an empty read), which nothing above
+        # catches. Found by fuzzing (KAN-194) within seconds of the harness's
+        # first real run, not reasoned out in advance -- see
+        # tests/test_support.py's regression test for the exact bytes.
+        # Everything in the block above is either this function's own
+        # SupportFileError (already re-raised, above) or tarfile/gzip
+        # decoding attacker-controlled bytes, so the same "not a readable
+        # archive" framing applies regardless of the exception's exact type.
+        raise SupportFileError(f"{path} is not a readable gzipped tar archive: {exc}") from exc
     _finish_archive_stats(stats, walked=walked, entries=entries, found=found)
     return found
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -650,6 +650,21 @@ class TestRefusals:
         with pytest.raises(SupportFileError, match="not a readable gzipped tar"):
             load_support_file(path)
 
+    def test_a_truncated_gzip_header_is_reported_clearly(self, tmp_path):
+        # Found by fuzzing (KAN-194), not written in advance: tarfile's
+        # streaming ("r|gz") mode hand-rolls its own gzip-header reader, and a
+        # stream that ends mid-header raises a bare TypeError from deep
+        # inside tarfile.py rather than tarfile.TarError, which nothing
+        # upstream of this project's own except clauses used to catch.
+        #
+        # gzip magic + deflate method + the FEXTRA flag bit set + a 4-byte
+        # mtime, then nothing: FEXTRA promises a 2-byte length field next,
+        # which the stream does not have.
+        path = tmp_path / "truncated.tgz"
+        path.write_bytes(b"\x1f\x8b\x08\x04\x00\x00\x00\x00")
+        with pytest.raises(SupportFileError, match="not a readable gzipped tar"):
+            load_support_file(path)
+
     def test_a_missing_file_is_reported_clearly(self, tmp_path):
         with pytest.raises(SupportFileError, match="Could not read"):
             load_support_file(tmp_path / "absent.tgz")


### PR DESCRIPTION
## Summary
Response to OSSF Scorecard scoring Fuzzing at 0/10. Adds ClusterFuzzLite (libFuzzer via Atheris, self-hosted in this repo's own CI) targeting `support.py`'s `load_support_file` -- the one parser this project already treats as hostile input by its own threat model (support files are attacker-supplied).

- `.clusterfuzzlite/fuzz_support_archive.py` -- the harness. Writes each candidate to a temp file (`load_support_file` takes a path, no in-memory entry point) and swallows only `SupportFileError`, the library's own "not valid" signal.
- `.clusterfuzzlite/make_seed_corpus.py` -- generates a tiny valid archive at build time so the fuzzer doesn't spend its whole budget failing the gzip magic-byte check. Not committed as a binary, generated fresh each build.
- `.clusterfuzzlite/Dockerfile` + `build.sh` + `project.yaml` -- standard ClusterFuzzLite Python build.
- `.github/workflows/cifuzz.yml` -- PR-triggered (path-filtered to `support.py`, `client.py`, and `.clusterfuzzlite/**`), 300s `code-change` mode. Not a required status check, so it can't block merges by itself.
- `CLAUDE.md` and `sonar-project.properties` updated to document the reasoning and exclude the new directory from the coverage metric (matches how `scripts/**` is already handled -- real code worth analyzing, but not reachable from pytest).

Full reasoning, including why ClusterFuzzLite over an OSS-Fuzz application and why this isn't scheduled/batch mode yet, is in CLAUDE.md's new "Fuzzing" section.

KAN-194.

## Test plan
- [x] `make check` passes locally
- [x] Seed corpus generator verified standalone: produces a valid archive that `load_support_file` actually parses successfully (not just past the "missing members" gate)
- [x] Both new Python files pass `ruff format --check` and `ruff check`
- [ ] Watch this PR's own `cifuzz.yml` run -- the real proof the Docker build and harness work, since a `gcr.io/oss-fuzz-base` build isn't practical to reproduce locally