### PR TITLE
Add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![SonarQube Cloud Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=gitkodak_unifi-map&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=gitkodak_unifi-map)
 [![SonarQube Cloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=gitkodak_unifi-map&metric=coverage)](https://sonarcloud.io/summary/new_code?id=gitkodak_unifi-map)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/gitkodak/unifi-map/badge)](https://securityscorecards.dev/viewer/?uri=github.com/gitkodak/unifi-map)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14071/badge)](https://www.bestpractices.dev/projects/14071)
 
 Export a UniFi network topology as **zoomable vector diagrams** and **editable
 draw.io files**, using real Ubiquiti product artwork.


### PR DESCRIPTION
## Summary
- Adds the OpenSSF Best Practices badge to README.md, next to the CI/SonarQube/Scorecard badges. Project passed today: https://www.bestpractices.dev/projects/14071

## Test plan
- [x] `make check` passes locally (README-only change)