### PR TITLE
Revert atheris to 3.0.0; exclude .clusterfuzzlite from auto-merge

### DIFF
--- a/.clusterfuzzlite/requirements.in
+++ b/.clusterfuzzlite/requirements.in
@@ -1,5 +1,9 @@
-# Pinned to 3.0.0, not the newest release: see Dockerfile for why.
+# Pinned to 3.0.0, not the newest release: see Dockerfile for why. Dependabot
+# will offer 3.1.0 again (it did once already, see dependabot-auto-merge.yml
+# and CLAUDE.md's Fuzzing section for what happened) -- check that a cp311
+# wheel exists before accepting a bump, not just that pip-compile can
+# generate hashes for whatever PyPI happens to publish.
 # Regenerate requirements.txt with:
 #   pip-compile --generate-hashes --allow-unsafe \
 #     --output-file=.clusterfuzzlite/requirements.txt .clusterfuzzlite/requirements.in
-atheris==3.1.0
+atheris==3.0.0

--- a/.clusterfuzzlite/requirements.txt
+++ b/.clusterfuzzlite/requirements.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=.clusterfuzzlite/requirements.txt .clusterfuzzlite/requirements.in
 #
-atheris==3.1.0 \
-    --hash=sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011 \
-    --hash=sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011 \
-    --hash=sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b \
-    --hash=sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b \
-    --hash=sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39 \
-    --hash=sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39
-    # via -r requirements.in
+atheris==3.0.0 \
+    --hash=sha256:1f0929c7bc3040f3fe4102e557718734190cf2d7718bbb8e3ce6d3eb56ef5bb3 \
+    --hash=sha256:510e502c57b6dc615fb174066407af620d4c7f73cf08a782c86e7761bf12c4eb \
+    --hash=sha256:8a5c8a781467c187da40fd29139784193e2647058831f837f675d0bb8cbd8746 \
+    --hash=sha256:a402cdca8a650d1371050b1f9552eb4cdc488d2db64950d603c4560318365eac
+    # via -r .clusterfuzzlite/requirements.in

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -58,9 +58,20 @@ jobs:
         # Stated positively, an unknown value merges nothing. The failure is
         # then a bump sitting unmerged, which somebody notices, rather than one
         # merging itself, which nobody does.
+        # /.clusterfuzzlite is excluded regardless of update-type. Found the
+        # hard way: atheris 3.0.0 -> 3.1.0 is a minor bump and auto-merged
+        # despite the fuzzing build itself failing, because `PR fuzzing`
+        # (cifuzz.yml) is deliberately not a required status check -- it's
+        # path-filtered, so making it required would block every other PR
+        # forever waiting on a check that never runs for them. That leaves
+        # required-checks-only auto-merge blind to exactly the failure that
+        # matters most for this one directory. See CLAUDE.md's Fuzzing
+        # section for the full incident.
         if: >-
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.meta.outputs.update-type == 'version-update:semver-patch'
+          steps.meta.outputs.directory != '/.clusterfuzzlite' && (
+            steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+            steps.meta.outputs.update-type == 'version-update:semver-patch'
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1769,6 +1769,26 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
     an index. Dismissed on GitHub as a false positive with that reasoning
     recorded, rather than left open or "fixed" by contorting an install that
     was already correct.
+
+  **A third pass, hours later: Dependabot bumped atheris 3.0.0 -> 3.1.0 and
+  `dependabot-auto-merge.yml` merged it, and it broke the fuzzing build.**
+  3.1.0 ships wheels for cp312/cp313/cp314 but not cp311, and
+  `oss-fuzz-base`'s Python is 3.11 -- the exact same wheel-availability gap
+  that picked 3.0.0 over 3.1.0 in the first place, just discovered a second
+  time instead of remembered. `PR fuzzing` (`cifuzz.yml`) failed on that PR
+  and was ignored, because it is deliberately not a required status check:
+  it is path-filtered to files that touch fuzzing, so making it required
+  would leave every other PR blocked forever on a check that never runs for
+  them. `dependabot-auto-merge.yml`'s policy only looks at required checks
+  passing, which made it blind to the one check that mattered here.
+
+  Fixed two ways, not one: the pin was reverted (3.0.0, same hashes as
+  before), and `dependabot-auto-merge.yml`'s condition now excludes
+  `/.clusterfuzzlite` from auto-merge entirely, regardless of update-type,
+  using `fetch-metadata`'s `directory` output. Reverting the pin fixes this
+  one bump; excluding the directory is what stops the next one from merging
+  itself the same way, since Dependabot will offer 3.1.0 again and nothing
+  about *that* PR will look different from any other minor bump.
 - **SonarQube Cloud runs inside `ci.yml`'s test job, not as Automatic
   Analysis.** `sonar-project.properties` says why in its first line: only an
   explicit analysis can import Python coverage, and Automatic Analysis was


### PR DESCRIPTION
## Summary
main is currently broken: Dependabot bumped atheris 3.0.0 -> 3.1.0 (#17, a minor bump) and `dependabot-auto-merge.yml` merged it despite `PR fuzzing` failing on that exact PR, because that check is deliberately not required (it's path-filtered, so requiring it would block every unrelated PR forever waiting on a check that never runs for them).

3.1.0 has wheels for cp312/cp313/cp314 but not cp311, and oss-fuzz-base's Python is 3.11 -- the same reason 3.0.0 was picked over 3.1.0 in #16, just rediscovered instead of remembered.

Fixed two ways:
- Reverted the pin to 3.0.0 (same hashes as before #17).
- `dependabot-auto-merge.yml` now excludes `/.clusterfuzzlite` from auto-merge entirely, regardless of update-type, using `fetch-metadata`'s `directory` output. Dependabot will offer 3.1.0 again eventually; this time it'll sit for manual review instead of merging itself.

KAN-194. Full incident writeup in CLAUDE.md's Fuzzing section.

## Test plan
- [x] `make check` passes locally
- [x] Confirmed the reverted lock's hashes match the pre-#17 state exactly
- [ ] Watch this PR's own PR fuzzing job -- should pass again with 3.0.0