### PR TITLE
Fix the remaining SonarQube findings

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,8 @@ on:
     - cron: "0 9 * * 3"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: scorecard-${{ github.ref }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,24 @@ sonar.python.coverage.reportPaths=coverage.xml
 # analyzed, but do not distort the application's coverage. Neither runs under
 # pytest, so without this every line in both would show as uncovered.
 sonar.coverage.exclusions=scripts/**,.clusterfuzzlite/**
+
+# ci.yml's "Install" step's local package line (pip install --no-deps
+# --only-binary=:all: -e .) is flagged by githubactions:S8541/S8544 as
+# unpinned/not-binary-only. Both are false positives that cannot be fixed by
+# changing the command: -e (editable) is what lets pytest-cov's coverage.xml
+# report paths under src/unifi_map/ rather than a site-packages copy, which
+# is what sonar.coverage.exclusions above and sonar.sources up top actually
+# depend on -- verified directly: dropping -e moves every filename in
+# coverage.xml to site-packages/unifi_map/..., which breaks the coverage
+# import entirely. --only-binary=:all: cannot apply to an editable local
+# install regardless (there is no prebuilt wheel for a live-linked path),
+# which is what the rule is actually detecting; it just cannot tell that
+# apart from a real unpinned third-party fetch. The same false positive on
+# .clusterfuzzlite/build.sh's near-identical non-editable line was dismissed
+# on GitHub as a false positive (code-scanning alert #14) for the same
+# underlying reason: nothing here is a fetched dependency to pin or hash.
+sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S8541
+sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/ci.yml
+sonar.issue.ignore.multicriteria.e2.ruleKey=githubactions:S8544
+sonar.issue.ignore.multicriteria.e2.resourceKey=.github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Quality gate was failing on `main` (rating C). Four open findings, two real, two the same false positive already seen once:

- **Real:** `scorecard.yml` still had `permissions: read-all` at workflow level -- missed in the earlier pass that fixed the identical pattern in `codeql.yml`, `dependabot-auto-merge.yml`, and `cifuzz.yml`. Fixed.
- **False positive, verified before touching anything:** `ci.yml`'s local install (`--no-deps --only-binary=:all: -e .`) is flagged as unpinned/not-binary-only. Tested dropping `-e` first rather than assuming -- it breaks `coverage.xml`'s file paths (they move from `src/unifi_map/...` to a `site-packages` copy), which would break SonarQube's own coverage import. Suppressed via `sonar.issue.ignore` instead, same reasoning as the identical false positive already dismissed on `.clusterfuzzlite/build.sh`'s line.
- **Intentionally left open, unchanged:** the base image running as root (MINOR, already documented).

## Test plan
- [x] `make check` passes locally
- [x] Verified dropping `-e` breaks coverage.xml's paths before ruling it out (not assumed)
- [ ] Watch this PR's own SonarCloud check -- should be clean or down to just the accepted root-user finding