### PR TITLE
Actually suppress the root-user Sonar finding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1740,11 +1740,19 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
   `oss-fuzz-base`'s Python/platform combination has no prebuilt wheel for
   `3.1.0`, and `--only-binary=:all:` refuses to fall back to a source build.
 
-  One finding was left open on purpose: the base image runs as root, flagged
-  as a MINOR finding and left with a comment explaining why, since
-  `oss-fuzz-base`'s own build tooling assumes it and the image is never
-  published anywhere -- it exists for the minutes this job runs and is
-  discarded after.
+  One finding was accepted rather than fixed: the base image runs as root,
+  flagged as a MINOR finding, since `oss-fuzz-base`'s own build tooling
+  assumes it and the image is never published anywhere -- it exists for the
+  minutes this job runs and is discarded after. **A Dockerfile comment
+  explaining that is not the same as resolving the issue.** The comment
+  landed first and the Sonar issue stayed open regardless, quietly capping
+  the security rating at B, which read as settled until it was pointed out
+  that the gate was still failing. Suppressed for real via
+  `sonar.issue.ignore` in `sonar-project.properties`, the same mechanism
+  used for the `ci.yml` false positives above -- worth remembering as its
+  own lesson: an explanatory comment in the flagged file and an actual
+  resolution in the tool that raised the finding are two different things,
+  and only one of them stops the tool from complaining.
 
   **A second pass, prompted by filling out the OSSF Best Practices badge
   form: `scorecard.yml` uploads its SARIF to GitHub's code-scanning alerts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,8 +27,19 @@ sonar.coverage.exclusions=scripts/**,.clusterfuzzlite/**
 # .clusterfuzzlite/build.sh's near-identical non-editable line was dismissed
 # on GitHub as a false positive (code-scanning alert #14) for the same
 # underlying reason: nothing here is a fetched dependency to pin or hash.
-sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria=e1,e2,e3
 sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S8541
 sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/ci.yml
 sonar.issue.ignore.multicriteria.e2.ruleKey=githubactions:S8544
 sonar.issue.ignore.multicriteria.e2.resourceKey=.github/workflows/ci.yml
+
+# .clusterfuzzlite/Dockerfile running as root (docker:S6471) is not a false
+# positive the way the two above are -- the finding is accurate, the image
+# really does run as root -- but it is accepted rather than fixable: the
+# Dockerfile's own comment above FROM explains why (oss-fuzz-base's build
+# tooling assumes it, the image is never published, it exists only for the
+# minutes this job runs). That comment alone does not resolve the Sonar
+# issue, which is what left it open and capping the security rating at B
+# after it was believed settled. This entry is what actually closes it.
+sonar.issue.ignore.multicriteria.e3.ruleKey=docker:S6471
+sonar.issue.ignore.multicriteria.e3.resourceKey=.clusterfuzzlite/Dockerfile


### PR DESCRIPTION
## Summary
The quality gate was still failing on `main` after the last fix -- pointed out directly. Root cause: the Dockerfile comment explaining that oss-fuzz-base needs root never actually resolved the corresponding SonarQube issue. A comment in the flagged file and a resolution in the tool that raised the finding are different things; only the latter stops the gate from failing.

Suppressed `docker:S6471` on `.clusterfuzzlite/Dockerfile` via `sonar.issue.ignore`, same mechanism as the two `ci.yml` suppressions already in place. This one differs slightly: it's not a false positive (the image genuinely runs as root), it's an accepted, documented risk -- `sonar.issue.ignore` covers both cases.

## Test plan
- [x] `make check` passes locally
- [ ] Watch this PR's own SonarCloud check and re-verify the quality gate on main after merge -- last time looked clean from the PR check alone but main's own branch analysis needed a separate push-triggered rescan to actually reflect it