### PR TITLE
Wire SCORECARD_TOKEN so Branch-Protection can actually be assessed

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,10 +4,12 @@ name: Scorecard analysis
 # list -- but a different axis from CodeQL and SonarQube Cloud): it doesn't
 # look for bugs in this code, it checks supply-chain hygiene of the
 # repository itself — branch protection, pinned CI dependencies, whether
-# Dependabot and a security policy exist, and so on. The public repo runs on
-# the default GITHUB_TOKEN; no PAT is needed here (that's only required for
-# classic Branch Protection or private repos, per the action's own
-# authentication docs).
+# Dependabot and a security policy exist, and so on. The default GITHUB_TOKEN
+# covers every check but one: Branch-Protection needs to read this repo's
+# classic branch protection rules, which GITHUB_TOKEN cannot do (a
+# GitHub-side restriction, not something scoped by permissions: below), so
+# SCORECARD_TOKEN is a fine-grained PAT with just "Administration: Read-only"
+# on this one repo, per the action's own authentication docs.
 
 on:
   push:
@@ -48,6 +50,7 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1639,6 +1639,15 @@ Live fetches are unaffected either way: `stat/sta` reports addresses directly.
   exists, for the project site; it isn't part of this group because it
   answers neither a quality nor a security question.)
 
+- **`scorecard.yml` reads `secrets.SCORECARD_TOKEN`, a fine-grained PAT scoped
+  to this one repo with `Administration: Read-only` only.** Added 2026-08-14
+  so Scorecard's Branch-Protection check can read this repo's classic branch
+  protection rules at all, which the default `GITHUB_TOKEN` cannot do
+  regardless of what `permissions:` grants it -- a GitHub-side restriction on
+  that specific API, not a scoping choice of ours. Every other check in the
+  workflow runs on `GITHUB_TOKEN` as before; this is additive, not a
+  replacement.
+
 - **Fuzzing: `cifuzz.yml`, ClusterFuzzLite, self-hosted rather than an OSS-Fuzz
   application.** Prompted by OSSF Scorecard scoring Fuzzing at 0. OSS-Fuzz
   proper means a second repository (`google/oss-fuzz`) to keep in sync and an


### PR DESCRIPTION
## Summary
Scorecard's Branch-Protection check has been erroring since it was added ("some github tokens can't read classic branch protection rules"). The default `GITHUB_TOKEN` genuinely cannot read this repo's classic branch protection rules -- a GitHub-side restriction on that specific API, unrelated to `permissions:` scoping.

Added a fine-grained PAT (`Administration: Read-only`, scoped to this one repo only) as the `SCORECARD_TOKEN` repo secret, referenced via `repo_token`. Every other check in the workflow keeps running on `GITHUB_TOKEN` as before -- this is additive.

## Test plan
- [x] `make check` passes locally (workflow-only change)
- [ ] Watch this PR's own checks, and confirm on the next Scorecard run (push-triggered, not PR-triggered) that Branch-Protection reports a real score instead of erroring