### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ told something untrue and may have acted on it.
 
 ## Unreleased
 
+## 0.11.1 - 2026-08-14
+
 ### Changed
 
 - **The project now states its socialist free-software values.** `VALUES.md`,
@@ -64,6 +66,14 @@ told something untrue and may have acted on it.
   when a sustained contributor collective exists. A hammer-and-sickle mark
   identifies that statement without making political identity a condition of
   use or contribution.
+
+### Fixed
+
+- **A corrupted or truncated `--support-file` archive no longer crashes the
+  run.** A gzip stream that ends partway through its header raised an
+  unhandled `TypeError` from deep inside Python's own `tarfile` module, which
+  nothing caught. It now fails the same clean way any other unreadable
+  archive does, naming the file rather than printing a traceback.
 
 ## 0.11.0 - 2026-08-11
 

--- a/TODO.md
+++ b/TODO.md
@@ -264,9 +264,6 @@ Recorded so they are not re-proposed as oversights.
   to make it do so is a proposal to reverse this decision rather than to finish
   it.
 
-- **A dependency lock file.** Hashed constraints are ongoing maintenance for a
-  dev-only benefit, and Dependabot plus the advisory job cover staying current.
-  Revisit if this ever ships an artifact people install.
 - **NetBox / IPAM export.** Subsumed by `-f json`, which ships, rather than
   refused: the ask was structured JSON *for importing into* NetBox, and once
   that export exists, a transform against our stable schema beats us tracking

--- a/docs/output.md
+++ b/docs/output.md
@@ -163,7 +163,7 @@ complete:
 ```json
 {
   "schema": 1,
-  "generator": "unifi-map 0.11.0",
+  "generator": "unifi-map 0.11.1",
   "title": "Network map",
   "counts": {
     "gateway": 1, "switch": 4, "ap": 3, "internet": 1,
@@ -175,7 +175,7 @@ complete:
       "ip": "10.0.0.1", "model": "UDMPROMAX", "detail": "UDMPROMAX",
       "sysid": 59954 }
   ],
-  "edges": [ { "child": "02:00:00:00:01:01", "parent": "internet", "label": "WAN", "provenance": "wan" } ]
+  "edges": [ { "child": "02:00:00:00:01:01", "parent": "internet", "provenance": "wan", "label": "WAN" } ]
 }
 ```
 

--- a/src/unifi_map/__init__.py
+++ b/src/unifi_map/__init__.py
@@ -6,4 +6,4 @@
 # Semantic versioning, currently pre-1.0: the minor number moves for new
 # behaviour, the patch number for fixes, and anything may still change until
 # 1.0. See CHANGELOG.md.
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/unifi-map.1
+++ b/unifi-map.1
@@ -1,4 +1,4 @@
-.TH UNIFI\-MAP 1 "2026-08-11" "unifi\-map 0.11.0" "User Commands"
+.TH UNIFI\-MAP 1 "2026-08-14" "unifi\-map 0.11.1" "User Commands"
 .SH NAME
 unifi\-map \- export a UniFi network topology as vector diagrams
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary
Cutting 0.11.1. The only user-visible change: a corrupted or truncated `--support-file` archive no longer crashes the run with an unhandled `TypeError` (found by fuzzing, KAN-194, fixed the same day). Everything else from today -- CI/CD hardening, fuzzing infrastructure, SonarQube maintainability fixes -- is repo/build tooling, correctly excluded from the changelog per its own rule ("what a user would notice").

Also: version bump, regenerated man page and JSON doc example, and a stale `TODO.md` entry (declined dependency lock file, reversed today as KAN-191) removed rather than left wrong.

Independently validated against a separate checkout before this PR: 681 tests passing, ruff clean, and confirmation that the JSON export carries provenance for both nodes and edges.

## Test plan
- [x] `make check` passes locally
- [x] Independently re-verified from a second checkout
- [ ] Watch this PR's own checks before tagging and publishing the Release