### PR TITLE
Reconcile release docs and fix a release-provenance retry bug

### DIFF
--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -43,9 +43,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        # -p selects only the three build artifacts, never *.intoto.jsonl. A
+        # workflow_dispatch retry runs against a release that may already
+        # carry attestation bundles from an earlier pass; downloading those
+        # too would attest and re-upload them as
+        # wheel.intoto.jsonl.intoto.jsonl, growing the release assets on
+        # every retry instead of cleanly re-attesting the same three files.
         run: |
           gh release download "$TAG" \
-            --repo "${{ github.repository }}" --dir artifacts --skip-existing
+            --repo "${{ github.repository }}" --dir artifacts --skip-existing \
+            -p '*.whl' -p '*.tar.gz' -p 'unifi-map.1'
 
       - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ told something untrue and may have acted on it.
 
 ## Unreleased
 
-## 0.11.1 - 2026-08-14
+## 0.11.1 - 2026-08-13
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1351,10 +1351,19 @@ grep -m2 "^## " CHANGELOG.md
 python -c "from unifi_map import __version__; print(__version__)"
 ```
 
-**The GitHub repository description is set**, and matches `pyproject.toml`.
-Verified against the API rather than assumed, because it is a setting rather
-than a file and so cannot be seen from a checkout. Check it the same way before
-listing it as outstanding again:
+**The GitHub repository description is set, and deliberately does not match
+`pyproject.toml`.** Both used the same "Export a UniFi network topology as
+zoomable vector diagrams and editable draw.io files" phrase (which still lives
+in `pyproject.toml`, `README.md`'s opening line, `__init__.py`'s docstring and
+`cli.py`'s argparse description) until the GitHub setting was edited on its own
+to spell out the format list instead: "Export UniFi Network topology to SVG,
+PDF, PNG, HTML, DOT, Mermaid, JSON, and editable draw.io diagrams." Found
+during a 2026-08-13 reconciliation, where this paragraph's own claim that the
+two matched turned out to be false. Decided to keep the divergence rather than
+force them back in sync: the repo description is what shows up in search and
+the repo list, where naming every output format is worth more than reusing the
+in-tool phrase verbatim. Check the setting itself before claiming anything
+about it, since it is invisible from a checkout:
 
 ```bash
 curl -s https://api.github.com/repos/gitkodak/unifi-map | jq -r .description

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,16 +103,26 @@ Read `## Unreleased` in `CHANGELOG.md` end to end. Specifically confirm:
    parts of a release most likely to be wrong, and they are the parts a diff
    shows worst. See the publishing order in `CLAUDE.md`.
 
-7. **Push to `origin`, then tag, then push the tag.**
+7. **Push a branch, open a PR against `origin`, merge, then tag.** `main`
+   requires a pull request as of 2026-08-13 (KAN-192) — branch protection sets
+   `enforce_admins: true`, so a direct `git push origin main` fails outright,
+   including for the repo owner. Zero approvals are required (see `CLAUDE.md`'s
+   publishing section for why); the required status checks passing is what
+   actually gates the merge.
 
    ```bash
-   git push origin main
+   git push origin HEAD:release/vX.Y.Z
+   gh pr create --title "Release vX.Y.Z" --body "…"
+   # wait for Python 3.11 / 3.12 / 3.13 and Repository hygiene to pass
+   gh pr merge --squash
+   git checkout main && git pull origin main
    git tag -a vX.Y.Z -m "…"      # annotated, summarising the headline changes
    git push origin vX.Y.Z
    ```
 
-   In that order. Tagging a commit that is not yet on the remote works locally
-   and confuses everything afterwards.
+   `git pull` before tagging matters: a squash merge gives the commit on `main`
+   a different SHA than the one just pushed, and tagging a commit that is not
+   yet on the remote works locally and confuses everything afterwards.
 
 8. **`make build`.** Empties `dist/` and writes a fresh wheel and sdist for
    *this* version. Nothing before this step needs it, but the next one
@@ -216,32 +226,27 @@ Read `## Unreleased` in `CHANGELOG.md` end to end. Specifically confirm:
 
 ## The undecided part
 
-**There is no published artifact.** A release here is a tag, a changelog entry
-and a GitHub Release carrying that entry.
+**There is no published artifact on PyPI.** A release here is a tag, a
+changelog entry, and a GitHub Release with the wheel, sdist and man page
+attached (step 9).
 
-Building one locally is not the undecided part and is documented: `make build`
-produces a wheel and an sdist in `dist/`, and `pip install dist/*.whl` works
-anywhere. Nothing about that is a promise to anyone, which is exactly why it
-sits outside this section.
-
-Note that the Release itself is not the undecided part, and stopped being
-optional at 0.8.0: it costs nothing, breaks no promises, and is what makes the
-version history visible from outside a checkout. What is still undecided is
-whether anything should be *attached* to one.
-
-Whether that should change is a real decision, not an oversight:
+That attachment is not the undecided part, and stopped being open at 0.10.0:
+`make build` produces a wheel and an sdist in `dist/`, the man page ships in
+the wheel via `[tool.setuptools.data-files]`, and `docs/install-from-github.md`
+documents `pip install <url>` straight off the Release page. What is still
+undecided is *PyPI* specifically:
 
 * Publishing to PyPI means owning the name, keeping metadata honest, and never
-  breaking a published artifact. It also makes `pip install unifi-map` work,
-  which is what people expect of a Python tool.
+  breaking a published artifact. It also makes `pip install unifi-map` work
+  with no URL to find first, which is what people expect of a Python tool.
 * The entry point and build backend already exist, and `make build` drives
   them, so there is no build work left in either direction. CI would need a
-  `tags:` trigger to build and attach or upload them.
+  `tags:` trigger to build and upload on release.
 * Graphviz is a system dependency, so a wheel is not self-contained either way.
-* Since 0.5.0 there is a man page, which packaging would have to place in
-  `share/man/man1` for `man unifi-map` to work rather than `man ./unifi-map.1`.
-  That is a small amount of work and one more thing to keep correct, so it
-  belongs on this side of the decision rather than being discovered after it.
 
-Until that is decided, this file describes a tag-and-changelog release, and says
-so rather than implying more.
+Stated 2026-08-03: not happening any time soon. It is a timing position, not a
+decline, and could change — but treat publishing workflows, trusted publishing,
+and PyPI-shaped packaging metadata as out of scope until it does.
+
+Until that changes, this file describes a tag-plus-Release release, and says so
+rather than implying more.

--- a/unifi-map.1
+++ b/unifi-map.1
@@ -1,4 +1,4 @@
-.TH UNIFI\-MAP 1 "2026-08-14" "unifi\-map 0.11.1" "User Commands"
+.TH UNIFI\-MAP 1 "2026-08-13" "unifi\-map 0.11.1" "User Commands"
 .SH NAME
 unifi\-map \- export a UniFi network topology as vector diagrams
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- Reconciled `RELEASING.md`, `CHANGELOG.md` and `CLAUDE.md` against actual repo/Jira/GitHub state:
  - `RELEASING.md` step 7 still said `git push origin main`, which now fails outright under the branch protection KAN-192 added; rewrote it to push a branch, open a PR, wait for required checks, then tag.
  - `RELEASING.md`'s closing section claimed GitHub Release artifact-attachment was still undecided, contradicting its own step 9 (which already does it, shipped at 0.10.0).
  - `CHANGELOG.md` dated 0.11.1 a day ahead of the release commit's local date; regenerated the man page (`make docs`) since its header date derives from that entry.
  - `CLAUDE.md` claimed the GitHub repo description matches `pyproject.toml`; it doesn't (deliberately, per discussion) — rewrote the paragraph to say so.
  - Jira (KAN-114/KAN-144 children) matched `TODO.md`/`CLAUDE.md` throughout, so no ticket-status changes were needed.
- Fixed a real bug in `release-provenance.yml` found by external review: a `workflow_dispatch` retry against a release that already carries `.intoto.jsonl` attestation bundles would download those too, attest them, and re-upload them as `wheel.intoto.jsonl.intoto.jsonl`, growing the release assets on every retry. Fixed by selecting only the three intended artifact types (`*.whl`, `*.tar.gz`, `unifi-map.1`) instead of downloading everything.

## Test plan

- [x] `make check` (ruff format/lint + 681 tests) passes clean
- [x] `make docs` produces no further changes (man page/flag reference regenerated and committed)
- [x] `make build` produces a working wheel/sdist, both containing the man page
- [x] Reviewed on `validate` before this PR
- [x] Two independent reviews of the two commits found no remaining issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)