### PR TITLE
Detect and report randomised client MAC addresses (KAN-129)

### DIFF
--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **681 automated tests**, none of which touch the network. They cover the
+- **686 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ told something untrue and may have acted on it.
 
 ## Unreleased
 
+### Added
+
+- **`--report` now says how many clients show a randomised MAC address.**
+  Every join here is on MAC, so a phone or laptop rotating its address (most
+  do, periodically) reappears as a new, unrelated client rather than as an
+  update to the one already on the map. Detected from IEEE 802's
+  locally-administered bit, which needs no cooperation from the controller.
+  Counted only, not named: there is nothing wrong with any specific device
+  and no overrides entry that would fix it.
+
 ## 0.11.1 - 2026-08-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1052,9 +1052,26 @@ to the three-way `cli/` package the reviews suggested without a reason per file.
   the argument for building it and is worth keeping as the measure of whether it
   earns its place.
 
-- **Randomised client MACs are not a concept here.** Every join is on MAC, so a
-  phone rotating its MAC appears as a new client with no relation to the old
-  one. Worth documenting at minimum, since it explains apparent duplicates.
+- **Randomised client MACs are not a concept the join layer knows about, but
+  `--report` now says so. Shipped** (KAN-129). Every join here is on MAC, so a
+  phone rotating its address appears as a new, unrelated client rather than an
+  update to the one already on the map — explaining an apparent duplicate was
+  the whole ask. `diagnostics._is_locally_administered()` checks IEEE 802's
+  locally-administered bit (bit 1 of the first octet) on each client's MAC,
+  which is what a randomisation feature sets and a vendor-burned address does
+  not, so this needed no cooperation from the controller and no new input.
+
+  **Counted, not named**, matching every other section's rule about what
+  qualifies for a name: an unplaced client or one with no address is a specific
+  problem an overrides file can fix, and a rotated MAC is neither. Naming a
+  device here would imply an action the reader cannot actually take.
+
+  Only clients are counted, not infrastructure — this project's own demo
+  fixtures and several test fixtures use locally-administered MACs too (the
+  `02:` prefix, precisely so a fake address doesn't resemble a real vendor's),
+  which would make an unfiltered count meaningless on its own test suite.
+  Devices don't rotate their MAC regardless, so restricting to `Kind.WIRED_CLIENT`
+  / `Kind.WIRELESS_CLIENT` is correct on both grounds at once.
 
 - **Nothing has been profiled on a large site.** The joins are dictionary-based
   and probably fine, but `sysid_for_name()` scans the catalogue per candidate.

--- a/TODO.md
+++ b/TODO.md
@@ -42,9 +42,12 @@ drawn from a thin one look equally authoritative.
   and draw.io outputs. Everything else `Provenance` distinguishes turned out to
   already have a channel: node role via `Kind`, asserted via dotted, offline
   via dashed.
-- **Randomised client MACs** (KAN-129). Every join here is on MAC, so a phone
-  rotating its address appears as a new client unrelated to the old one. Explains
-  apparent duplicates. Detectable from the locally-administered bit.
+- **Randomised client MACs. Shipped**, as a `--report` section (KAN-129).
+  Every join here is on MAC, so a phone rotating its address appears as a new
+  client unrelated to the old one. `--report` now counts how many currently
+  show a locally-administered MAC and says why, without naming any of them:
+  there is nothing wrong with a specific device and no overrides entry that
+  would fix it.
 
 ## More ways to look at the network
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,6 +162,25 @@ diagram](#reading-the-diagram) — and an asserted one is drawn dotted, so this
 report and the picture agree rather than the report being the only place the
 distinction shows.
 
+**Every join here is on MAC address**, and most phones and laptops rotate
+theirs periodically. When that happens the same physical device reappears as
+an unrelated new client rather than as an update to the one already on the
+map — nothing is wrong, and there is no overrides entry that fixes it. A
+rotated MAC is detectable without any cooperation from the controller (it sets
+IEEE 802's locally-administered bit), so `--report` counts how many clients
+currently show one:
+
+```
+RANDOMISED MAC ADDRESSES
+  3 of 19 client(s) advertise a locally-administered
+  MAC, which most phones and laptops rotate periodically. The same physical
+  device can reappear here as a new client rather than as the one already on
+  the map; this is expected, and not something an overrides file can fix.
+```
+
+Counted rather than named, unlike the sections above: there is nothing wrong
+with any specific device here.
+
 **This report is not safe to share.** It names your devices, addresses and
 networks by design, and it says so at the top. For something you can paste into
 a bug report, use [`unifi-map shape`](sharing.md), which is built from an

--- a/src/unifi_map/diagnostics.py
+++ b/src/unifi_map/diagnostics.py
@@ -192,6 +192,51 @@ def _addressless_section(topo: Topology) -> list[str]:
     ] + [f"  {_describe(node)}" for node in nameless]
 
 
+def _is_locally_administered(mac: str) -> bool:
+    """True if bit 1 of the first octet is set (IEEE 802's locally-administered bit).
+
+    Set on an address that was generated rather than burned into hardware by a
+    vendor, which is what a MAC-randomisation feature produces. Malformed input
+    (a synthetic id like `"internet"` or `UNKNOWN_UPLINK_ID`) reads as False
+    rather than raising; callers only feed this client node ids, but the check
+    should not depend on that staying true.
+    """
+    first = mac.split(":", 1)[0]
+    try:
+        octet = int(first, 16)
+    except ValueError:
+        return False
+    return bool(octet & 0x02)
+
+
+def _mac_randomisation_section(topo: Topology) -> list[str]:
+    """How many clients advertise a locally-administered (rotating) MAC.
+
+    Every join in this tool is on MAC address, so a client that rotates its own
+    -- most phones and laptops do, periodically -- reappears here as a new,
+    unrelated client rather than as an update to the one already on the map.
+    KAN-129.
+
+    **Counted only, not named**, unlike the sections above. An unplaced client
+    or one with no address is a specific, fixable problem and an overrides file
+    is the fix. A rotated MAC is neither: there is nothing wrong with any one
+    device, and nothing to point an overrides file at. Naming devices here would
+    imply an action the reader cannot take.
+    """
+    clients = [n for n in topo.nodes.values() if n.kind in _CLIENT_KINDS]
+    randomised = sum(1 for n in clients if _is_locally_administered(n.id))
+    if not randomised:
+        return []
+    return [
+        "",
+        "RANDOMISED MAC ADDRESSES",
+        f"  {randomised} of {len(clients)} client(s) advertise a locally-administered",
+        "  MAC, which most phones and laptops rotate periodically. The same physical",
+        "  device can reappear here as a new client rather than as the one already on",
+        "  the map; this is expected, and not something an overrides file can fix.",
+    ]
+
+
 def _dangling_networks(topo: Topology) -> list[str]:
     """Networks a client claims to be on that the controller does not list.
 
@@ -416,6 +461,7 @@ def build_diagnostics(
     out += _unplaced_section(topo)
     out += _addressless_section(topo)
     out += _dangling_networks(topo)
+    out += _mac_randomisation_section(topo)
     out += _artwork_section(sources)
 
     if sources.notes:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -368,3 +368,58 @@ class TestObfuscation:
         text = build_diagnostics(obfuscate(topo))
         for label in real_labels:
             assert label not in text, f"{label!r} survived obfuscation into the report"
+
+
+class TestRandomisedMacAddresses:
+    """KAN-129: every join here is on MAC, so a rotated MAC looks like a new,
+    unrelated client rather than an update to the one already on the map."""
+
+    def _topo_with(self, *macs: str) -> Topology:
+        topo = Topology()
+        for i, mac in enumerate(macs):
+            topo.add(
+                Node(
+                    id=mac,
+                    label=f"client{i}",
+                    kind=Kind.WIRELESS_CLIENT,
+                    provenance=Provenance.CLIENT,
+                )
+            )
+        return topo
+
+    def test_absent_when_no_client_mac_is_locally_administered(self):
+        text = build_diagnostics(self._topo_with("00:11:22:33:44:55", "b8:27:eb:aa:bb:cc"))
+        assert "RANDOMISED MAC ADDRESSES" not in text
+
+    def test_counts_only_the_locally_administered_ones(self):
+        text = build_diagnostics(
+            self._topo_with("00:11:22:33:44:55", "aa:bb:cc:dd:ee:ff", "02:00:00:00:01:04")
+        )
+        assert "RANDOMISED MAC ADDRESSES" in text
+        assert "2 of 3 client(s)" in text
+
+    def test_infrastructure_macs_are_not_counted_as_clients(self):
+        """A switch or gateway can be locally administered too (this project's
+        own demo fixtures are); only clients are what MAC randomisation is
+        actually about, and infrastructure MACs don't rotate."""
+        topo = self._topo_with("aa:bb:cc:dd:ee:ff")
+        topo.add(Node(id="gw", label="gateway", kind=Kind.GATEWAY, provenance=Provenance.DEVICE))
+        text = build_diagnostics(topo)
+        assert "1 of 1 client(s)" in text
+
+    def test_names_no_device(self):
+        """Counted, not named: there is nothing wrong with any one device here,
+        and no overrides file entry that would fix it, so naming one would
+        imply an action the reader cannot actually take.
+
+        Gives the client an address so `_addressless_section` -- a different
+        section, with a different and legitimate reason to print a name --
+        does not fire and confound the assertion.
+        """
+        topo = self._topo_with("aa:bb:cc:dd:ee:ff")
+        topo.nodes["aa:bb:cc:dd:ee:ff"].ip = "10.0.0.5"
+        text = build_diagnostics(topo)
+        assert "client0" not in text
+
+    def test_malformed_mac_does_not_raise(self):
+        build_diagnostics(self._topo_with("not-a-mac"))


### PR DESCRIPTION
## Summary

Implements KAN-129, the one open ticket that fit unattended overnight work: fully specified already ("detectable from the locally-administered bit"), self-contained, no design judgment calls left for a human, deterministic and testable.

- `--report` now includes a `RANDOMISED MAC ADDRESSES` section counting how many clients currently advertise a locally-administered MAC (IEEE 802 bit 1 of the first octet) — the bit a MAC-randomisation feature sets and a vendor-burned address does not. Needs no cooperation from the controller.
- Counted only, not named, matching every other report section's rule: there's nothing wrong with any one device and no overrides entry that fixes it.
- Restricted to client kinds only — this project's own demo/test fixtures use locally-administered MACs too (the `02:` prefix, so fakes don't resemble a real vendor's), which would make an unfiltered count meaningless on the test suite itself.
- Docs (`docs/usage.md`), `TODO.md`, and `CLAUDE.md` updated to match; `CHANGELOG.md` gained an `Unreleased` entry.
- `AI_DISCLOSURE.md`'s test count updated 681 → 686, caught by its own guard test.

## Test plan

- [x] `make check` (ruff format/lint + 686 tests) passes clean
- [x] New tests in `tests/test_diagnostics.py::TestRandomisedMacAddresses` cover: absent when nothing is randomised, correct count, infrastructure MACs excluded, no device named, malformed MAC doesn't raise
- [x] Verified against the real demo dataset (`unifi-map render --cache-dir examples/demo --report`) — section renders correctly
- [x] Reviewed on `validate` before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)