### PR TITLE
Stop an exported API key reaching the dot -V child process in shape

### DIFF
--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **686 automated tests**, none of which touch the network. They cover the
+- **694 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ told something untrue and may have acted on it.
   Counted only, not named: there is nothing wrong with any specific device
   and no overrides entry that would fix it.
 
+### Fixed
+
+- **`unifi-map shape` no longer hands an exported `UNIFI_API_KEY` to the
+  `dot -V` child process it runs to report your Graphviz version.** The two
+  Graphviz child processes used to actually render a map have stripped an
+  exported key from their environment since early on; this third one, added
+  later purely to report a version number, was missed. `shape` is
+  specifically the command meant to be safe to paste into a bug report.
+  Found by external review.
+
 ## 0.11.1 - 2026-08-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,15 +157,30 @@ controller JSON.
    snapshot cache so `--cache-dir examples/demo` doesn't get downloads written
    into it.
 5. **`layout.py`** is the only module that shells out to Graphviz (`dot`,
-   `unflatten`). Both are executed by the absolute path `shutil.which` resolved,
-   not by bare name, so what runs is what was found rather than whatever `PATH`
-   resolves to at exec time. Both get `_child_env()`, the parent environment
-   with any API key removed.
+   `unflatten`) to render. Both are executed by the absolute path `shutil.which`
+   resolved, not by bare name, so what runs is what was found rather than
+   whatever `PATH` resolves to at exec time. Both get `child_env()`, the parent
+   environment with any API key removed.
 
    That pairs with `config.py` never writing a credential into `os.environ`:
    `read_dotenv()` returns a mapping and `load_config()` merges it under the
    real environment. Keep it that way. An API key in the process environment is
    inherited by every child, and Graphviz comes off `PATH`.
+
+   **A third Graphviz child process was missed when this scrubbing was added,
+   found by external review of 2db752d and fixed the same day.**
+   `cli._graphviz_version()` — what `unifi-map shape` reports, specifically the
+   command meant to be safe to paste into a bug report — ran `dot -V` with the
+   plain inherited environment, not `child_env()`. This is exactly the "fix the
+   class, not the instance" failure named elsewhere in this file: the scrubbing
+   was added to the two render call sites and the third, added separately for
+   version reporting, was never revisited. `child_env()` was promoted out of
+   `layout.py`'s privacy (it was `_child_env`) rather than reimplemented in
+   `cli.py`, since a helper with two production callers across two modules is a
+   shared primitive, not one module's internal detail — the same reasoning that
+   moved the capped-read primitive into `httpio.py`. A regression test runs a
+   stand-in `dot` and asserts the exported key never reaches it, mutation-tested
+   by confirming it failed red against the pre-fix code.
 6. **`render_dot.py` / `render_drawio.py` / `svg_post.py`** are pure functions
    from `Topology` to text. `theme.py` holds every colour, shape and label.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -236,8 +236,13 @@ valid certificate, or at a CA bundle path, is better where possible.
   for `Authorization` and nothing else, and ours is a custom `X-API-KEY` header.
   A redirect that changes host, port or scheme drops it and says so. Redirects
   themselves still work, so a reverse proxy in front of your console is fine.
-- **Graphviz is executed by resolved absolute path**, not by name, so a binary
-  earlier on `PATH` cannot stand in for it.
+- **Graphviz is resolved once to an absolute path and that exact path is what
+  gets executed**, not the bare name `dot` re-resolved at call time. This
+  guards against a substitution *after* resolution — `PATH` changing, or the
+  file at that path being swapped — not against `PATH` itself: whatever is
+  first on `PATH` when this tool starts is what gets found, same as any other
+  program that shells out by name. Put a directory you do not control ahead of
+  a trusted Graphviz install on `PATH` and this offers no protection.
 - **A credential file that other local accounts can read produces a warning**,
   and the file that was loaded is named, since `./.env` is searched before the
   home config.

--- a/src/unifi_map/cli.py
+++ b/src/unifi_map/cli.py
@@ -714,14 +714,29 @@ def _graphviz_version() -> str | None:
 
     Every rendering claim here is verified against one version, so knowing
     somebody else's is worth a line.
+
+    Runs `dot` with `layout.child_env()`, same as `run_dot()`/`unflatten()`.
+    This is a second, separate Graphviz child process from those two, and was
+    missed when the scrubbed environment was introduced for them -- it
+    inherited an exported `UNIFI_API_KEY` in full until fixed. Worth getting
+    right here specifically: this is what `unifi-map shape` reports, and
+    `shape` is the command meant to be safe to paste into a bug report.
     """
     import subprocess
+
+    from .layout import child_env
 
     executable = shutil.which("dot")
     if executable is None:
         return None
     try:
-        result = subprocess.run([executable, "-V"], capture_output=True, text=True, timeout=10)
+        result = subprocess.run(
+            [executable, "-V"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=child_env(),
+        )
     except (OSError, subprocess.SubprocessError):
         return None
     output = (result.stderr or result.stdout or "").strip()

--- a/src/unifi_map/diagnostics.py
+++ b/src/unifi_map/diagnostics.py
@@ -41,6 +41,7 @@ every clean run into a network inventory printed to stdout. A test pins it.
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 
@@ -192,21 +193,28 @@ def _addressless_section(topo: Topology) -> list[str]:
     ] + [f"  {_describe(node)}" for node in nameless]
 
 
+_MAC_SHAPE = re.compile(r"^[0-9a-f]{2}(:[0-9a-f]{2}){5}$")
+
+
 def _is_locally_administered(mac: str) -> bool:
     """True if bit 1 of the first octet is set (IEEE 802's locally-administered bit).
 
     Set on an address that was generated rather than burned into hardware by a
-    vendor, which is what a MAC-randomisation feature produces. Malformed input
-    (a synthetic id like `"internet"` or `UNKNOWN_UPLINK_ID`) reads as False
-    rather than raising; callers only feed this client node ids, but the check
-    should not depend on that staying true.
+    vendor, which is what a MAC-randomisation feature produces.
+
+    Requires the full six-octet colon-separated shape before parsing anything.
+    An earlier version parsed only the substring before the first colon, so a
+    truncated or malformed id -- `"2"`, say -- read as hex `0x02` and came back
+    locally-administered by accident, even though it is not a MAC at all. That
+    matters because `Node.id` is not trusted input here: `_norm_mac()` lowercases
+    a client's `mac` field but never validates its shape, and a support file's
+    fields are attacker-controlled by this project's own threat model. A
+    malformed id now reads as False rather than as a coin flip on its digits.
     """
-    first = mac.split(":", 1)[0]
-    try:
-        octet = int(first, 16)
-    except ValueError:
+    lowered = mac.lower()
+    if not _MAC_SHAPE.match(lowered):
         return False
-    return bool(octet & 0x02)
+    return bool(int(lowered[:2], 16) & 0x02)
 
 
 def _mac_randomisation_section(topo: Topology) -> list[str]:

--- a/src/unifi_map/layout.py
+++ b/src/unifi_map/layout.py
@@ -63,7 +63,7 @@ class Layout:
 _CREDENTIAL_VARS = ("UNIFI_API_KEY", "UDM_API_KEY")
 
 
-def _child_env() -> dict[str, str]:
+def child_env() -> dict[str, str]:
     """The parent environment with any API key removed."""
     return {k: v for k, v in os.environ.items() if k not in _CREDENTIAL_VARS}
 
@@ -88,7 +88,7 @@ def run_dot(dot_source: str, output_format: str, engine: str = "dot") -> bytes:
     try:
         result = subprocess.run(
             [executable, f"-T{output_format}"],
-            env=_child_env(),
+            env=child_env(),
             input=dot_source.encode("utf-8"),
             capture_output=True,
             timeout=300,
@@ -136,7 +136,7 @@ def stagger(dot_source: str, depth: int) -> str:
     try:
         result = subprocess.run(
             [executable, "-f", "-l", str(depth)],
-            env=_child_env(),
+            env=child_env(),
             input=dot_source.encode("utf-8"),
             capture_output=True,
             timeout=120,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -9,7 +9,7 @@ direction.
 from __future__ import annotations
 
 from unifi_map.client import Snapshot
-from unifi_map.diagnostics import Sources, build_diagnostics
+from unifi_map.diagnostics import Sources, _is_locally_administered, build_diagnostics
 from unifi_map.model import Edge, Kind, Node, Provenance, Topology, build_topology
 
 from .conftest import AP_MAC, SWITCH_MAC
@@ -423,3 +423,44 @@ class TestRandomisedMacAddresses:
 
     def test_malformed_mac_does_not_raise(self):
         build_diagnostics(self._topo_with("not-a-mac"))
+
+
+class TestIsLocallyAdministered:
+    """Direct tests of the bit check, not just the report it feeds.
+
+    `Node.id` is not trusted input: `_norm_mac()` lowercases a client's `mac`
+    field but never validates its shape, and a support file's fields are
+    attacker-controlled by this project's own threat model. A short or
+    malformed value must not be parsed as if it were a real MAC's leading
+    octet.
+    """
+
+    def test_a_real_locally_administered_mac(self):
+        assert _is_locally_administered("aa:bb:cc:dd:ee:ff") is True
+
+    def test_a_real_vendor_assigned_mac(self):
+        assert _is_locally_administered("00:11:22:33:44:55") is False
+
+    def test_case_insensitive(self):
+        assert _is_locally_administered("AA:BB:CC:DD:EE:FF") is True
+
+    def test_truncated_short_string_is_not_read_as_a_leading_octet(self):
+        """The regression this guards: `"2"` alone used to parse as hex `0x02`
+        and come back True, even though it is nowhere near a MAC."""
+        assert _is_locally_administered("2") is False
+        assert _is_locally_administered("02") is False
+        assert _is_locally_administered("aa:bb") is False
+
+    def test_overlong_string(self):
+        assert _is_locally_administered("aa:bb:cc:dd:ee:ff:00") is False
+
+    def test_non_hex_garbage(self):
+        assert _is_locally_administered("not-a-mac") is False
+        assert _is_locally_administered("") is False
+
+    def test_multicast_bit_is_not_confused_with_locally_administered(self):
+        """Bit 0 (multicast/unicast) and bit 1 (locally-administered) are
+        different bits of the same octet; only the second should matter here."""
+        assert _is_locally_administered("01:00:5e:00:00:01") is False
+        # Both bits set: multicast *and* locally-administered.
+        assert _is_locally_administered("03:00:00:00:00:00") is True

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -987,13 +987,13 @@ class TestCredentialsDoNotReachChildProcesses:
         assert "UNIFI_API_KEY" not in os.environ
 
     def test_an_exported_key_is_stripped_from_child_environments(self, monkeypatch):
-        from unifi_map.layout import _child_env
+        from unifi_map.layout import child_env
 
         monkeypatch.setenv("UNIFI_API_KEY", "super-secret")
         monkeypatch.setenv("UDM_API_KEY", "also-secret")
         monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
 
-        env = _child_env()
+        env = child_env()
         assert "UNIFI_API_KEY" not in env
         assert "UDM_API_KEY" not in env
         # Still a usable environment, not an empty one.
@@ -1003,15 +1003,42 @@ class TestCredentialsDoNotReachChildProcesses:
         """End to end: run a stand-in for `dot` that reports its environment."""
         import subprocess
 
-        from unifi_map.layout import _child_env
+        from unifi_map.layout import child_env
 
         monkeypatch.setenv("UNIFI_API_KEY", "super-secret")
         probe = tmp_path / "probe.py"
         probe.write_text("import os,sys; sys.stdout.write(os.environ.get('UNIFI_API_KEY',''))")
         result = subprocess.run(
-            [sys.executable, str(probe)], capture_output=True, env=_child_env(), check=False
+            [sys.executable, str(probe)], capture_output=True, env=child_env(), check=False
         )
         assert result.stdout == b""
+
+    def test_the_graphviz_version_probe_also_does_not_see_the_key(self, monkeypatch, tmp_path):
+        """`cmd_shape` calls `_graphviz_version()` to run `dot -V`, a second
+        Graphviz child process separate from `run_dot`/`unflatten` above. It was
+        missed when `child_env()` scrubbing was added to those, and inherited
+        the full environment -- including an exported key -- until fixed.
+        `unifi-map shape` is specifically the command meant to be safe to paste
+        into a bug report, which is what makes this one worth its own test
+        rather than trusting that "it's the same kind of subprocess" generalises.
+        """
+        from unifi_map.cli import _graphviz_version
+
+        marker = tmp_path / "seen.txt"
+        fake_dot = tmp_path / "dot"
+        fake_dot.write_text(
+            f"#!{sys.executable}\n"
+            "import os\n"
+            f"open({str(marker)!r}, 'w').write(os.environ.get('UNIFI_API_KEY', ''))\n"
+            "import sys; sys.stderr.write('dot - graphviz version 9.9.9 (test)\\n')\n"
+        )
+        fake_dot.chmod(0o755)
+        monkeypatch.setenv("UNIFI_API_KEY", "super-secret")
+        monkeypatch.setenv("PATH", str(tmp_path))
+
+        _graphviz_version()
+
+        assert marker.read_text() == "", "UNIFI_API_KEY leaked into the `dot -V` child process"
 
 
 class TestTheUdmNamesAreGone:


### PR DESCRIPTION
## Summary

Response to an external review of ccd1113 (KAN-129), which found three things. Two are fixed here; the third is a documented, deliberate trade-off with no code defect, so no change was made for it.

**Fixed — High: API key leak (`cli.py`)**
`unifi-map shape`'s Graphviz-version probe (`_graphviz_version`, called from `cmd_shape`) ran `dot -V` with the plain inherited environment rather than `layout.py`'s scrubbed one. The two Graphviz child processes used to actually render a map have stripped an exported `UNIFI_API_KEY` since early on; this third one, added later just to report a version number, was missed. `shape` is specifically the command meant to be safe to paste into a bug report.

Promoted `layout._child_env` to a public `child_env()` — it now has two production callers in two modules, so it's a shared primitive rather than one module's private detail. Added a regression test that runs a stand-in `dot` and confirms an exported key never reaches it; confirmed it fails red against the pre-fix code before applying the fix.

**Fixed — Low: malformed-MAC parsing (`diagnostics.py`)**
The KAN-129 randomised-MAC detector parsed only the substring before a MAC's first colon, so a malformed id like `"2"` read as hex `0x02` and came back locally-administered by accident. Now requires the full six-octet shape before checking the bit — relevant because `Node.id` isn't trusted input, and a support file's fields are attacker-controlled by this project's own threat model.

**Not changed — Medium: release-provenance timing**
The review noted the provenance workflow attests artifacts already built locally rather than building from the tagged source in CI. Correct, but already explicitly documented as a deliberate trade-off (`RELEASING.md` keeps the build local and manual on purpose; the workflow itself says it runs "after the fact"). No code or doc defect, so no change.

Also tightened a `SECURITY.md` claim the same review flagged as overclaiming: resolving Graphviz to an absolute path once guards against a substitution *after* resolution, not against `PATH` itself.

## Test plan

- [x] New regression test confirmed red against the pre-fix code, then green after the fix
- [x] `make check` (ruff format/lint + 694 tests) passes clean
- [x] `make docs` produces no further changes
- [x] Reviewed on `validate` before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)