### PR TITLE
Shared switch ports (KAN-199) and overrides generate (KAN-120)

### DIFF
--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **738 automated tests**, none of which touch the network. They cover the
+- **747 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **721 automated tests**, none of which touch the network. They cover the
+- **737 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **737 automated tests**, none of which touch the network. They cover the
+- **738 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/AI_DISCLOSURE.md
+++ b/AI_DISCLOSURE.md
@@ -28,7 +28,7 @@ by the human and carry a `Co-Authored-By` trailer naming the model.
 
 ## What has actually been verified
 
-- **747 automated tests**, none of which touch the network. They cover the
+- **753 automated tests**, none of which touch the network. They cover the
   parsing, the model, obfuscation, override handling, support-file reading, the
   renderers and several security properties directly.
 - **Continuous integration** on every push and pull request, plus a repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,28 @@ told something untrue and may have acted on it.
 
 ## Unreleased
 
+### Added
+
+- **Flag switch ports shared by several wired clients.** Several wired
+  clients reporting the same switch and port usually means an unmanaged
+  switch or a virtualisation host the controller cannot see, and needs no
+  cooperation from the hidden device to detect, unlike LLDP. The diagram
+  marks the shared edges with a small diamond at the child end, present in
+  every layout including the default `unifi`; `--layout tree` additionally
+  appends `*` to the port label. `--report` names the port and lists the
+  clients in a new `SHARED SWITCH PORTS` section, and the console warns once
+  per shared port, a bare count under `--obfuscate`. Never drawn as a node:
+  which of the two causes it is can't be told apart from here, so nothing is
+  synthesised either way.
+
+- **`unifi-map overrides generate` prints a commented overrides skeleton.**
+  Seeded from the same signals `--report` already names: clients with no
+  reported uplink, switch ports shared by several wired clients, and artwork
+  matches refused as ambiguous. Every block is commented out, so the file
+  changes nothing until edited and uncommented; the one field it never fills
+  in is a client's real uplink. `--report` now points at it from each of the
+  three sections it can help with.
+
 ## 0.12.0 - 2026-08-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -836,11 +836,23 @@ at anything requiring knowledge of UniFi.
   then failed the render it had just been checked for. The flag is now shared
   between the two subparsers rather than duplicated.
 
-- **`generate-overrides`**, emitting a skeleton `overrides.toml` seeded with the
-  nodes the tool could not place. Closes a loop that is currently half open: the
-  run already counts clients with no reported uplink and points at overrides,
-  and the "no reconciliation report" gap below is asking for the same
-  information from the other end. One command could answer both.
+- **`overrides generate`. Shipped**, 2026-08-16 (KAN-120). `unifi-map overrides
+  generate` prints a commented `overrides.toml` skeleton to stdout, seeded from
+  unplaced clients, shared switch ports (KAN-199) and ambiguous artwork
+  matches — the same three signals `--report` already names, closing the loop
+  that section originally described as half open. `--report` now points at it
+  from all three sections. `overrides.generate_candidates()` is the pure
+  function; `cmd_overrides`'s `generate` action just prints its result,
+  resolving artwork offline and best-effort the same way `unifi-map shape`
+  does, so it never touches the network and a catalogue miss cannot stop it
+  from printing what it did find.
+
+  A subcommand (`overrides generate`, sibling to the existing `overrides
+  check`) rather than a flag on `render`: this produces a config skeleton, not
+  a diagram, and `render` writing a second file type on the side would be a
+  strange thing for a rendering command to do. Being its own subcommand also
+  makes it opt-in for free, which Jason asked for explicitly — nobody reaches
+  it by accident, unlike a flag that could be left on by habit.
 
 - **Mermaid export. Shipped, as `-f mermaid`.** It necessarily loses artwork, so
   it is the shape of the network and nothing else, and the docs say so. Note
@@ -1072,7 +1084,14 @@ interface of a multi-homed host usually has a locally-administered MAC and an
 empty OUI, while genuinely distinct devices behind an unmanaged switch have
 neither. Both groups on the reference network separate cleanly on that test,
 which is what makes it safe for `--report` to mention (KAN-199) and for the
-stub generator to act on (KAN-120).
+candidates generator to act on (KAN-120).
+
+**The generator shipped 2026-08-16 and does not yet act on this signature.**
+`unifi-map overrides generate` (`overrides.generate_candidates`) covers the
+three signals `--report` already names — unplaced clients, shared switch
+ports, ambiguous artwork — none of which distinguish a multi-homed host from
+a genuinely hidden switch. Using the locally-administered-MAC test to
+annotate or split the shared-port candidate block is still open.
 
 ### Gaps worth considering
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -854,6 +854,27 @@ at anything requiring knowledge of UniFi.
   makes it opt-in for free, which Jason asked for explicitly — nobody reaches
   it by accident, unlike a flag that could be left on by habit.
 
+  **The generated TOML was not actually safe to uncomment, caught the same
+  day by external review of cfcd2fe.** A controller-supplied label (a switch
+  or client name) went straight into the skeleton unescaped. A `"` in it
+  broke the surrounding `name = "..."` value the moment the block was
+  uncommented -- the review's repro was a switch named `Core "A"`, which
+  generated `name = "Unmanaged switch (port 7 on Core "A")"`, invalid TOML.
+  Worse, a raw newline in a label would have ended the `#` line it sat on and
+  let whatever followed be read as real TOML, unreviewed -- a genuine break
+  of "inert until edited", the one promise this command makes, not merely a
+  cosmetic bug. Fixed with two small helpers in `overrides.py`:
+  `_comment_safe()` collapses whitespace (same technique as
+  `render_mermaid._flatten()`, reused rather than re-invented) so nothing can
+  end the line it sits on, and `_toml_value()` additionally escapes `\` and
+  `"` for the values that sit inside quotes. Applied to every place a label or
+  an id (MACs are just as attacker-controlled by this project's own threat
+  model, `_norm_mac()` never validates their shape) reaches the output, not
+  only the one the reviewer's repro happened to hit. Six tests pin it,
+  including one that parses the *entire* generated file with `tomllib` and
+  asserts it comes back empty, which is what a newline actually escaping the
+  comment would have broken.
+
 - **Mermaid export. Shipped, as `-f mermaid`.** It necessarily loses artwork, so
   it is the shape of the network and nothing else, and the docs say so. Note
   that its direction follows `--layout` (`unifi` gives LR, `tree` gives TB) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1093,9 +1093,10 @@ stub generator to act on (KAN-120).
   replacing it. Unverified and worth checking first: whether it is per-site,
   whether it clears, and whether an all-UniFi network ever sets it.
 
-- **Several wired clients on one switch port means something is hiding there**
-  (KAN-199). Found 2026-08-14 when Jason remembered a Netgear PoE switch the
-  map had been drawing wrong since the map existed.
+- **Several wired clients on one switch port means something is hiding there.
+  Shipped**, the shared-port half of KAN-199, 2026-08-16. Found 2026-08-14 when
+  Jason remembered a Netgear PoE switch the map had been drawing wrong since
+  the map existed.
 
   **The controller cannot see that switch at all**: no device entry, no client
   entry, no LLDP entry, no v2 topology edge. Both things behind it are reported
@@ -1105,17 +1106,39 @@ stub generator to act on (KAN-120).
   other occupied port on that switch has one. Two corroborating facts on the
   same port, worth quoting in the report when present but too weak to trigger
   on: `poe_enable = false` with `poe_power = 0.00` while a PoE camera runs
-  behind it, and 1000 Mb negotiated on `2P5GE`-capable media.
+  behind it, and 1000 Mb negotiated on `2P5GE`-capable media. Neither
+  corroborating fact is implemented; only the shared-port count is.
 
   **This is the general answer that LLDP is not.** LLDP needs the foreign
   device to advertise, and this one does not; a shared-port check needs nothing
   from it. See the LLDP entry above for the full correction.
 
-  **Report it, never draw it.** Several MACs on one port means an unmanaged
-  switch *or* a virtualisation host with bridged guests, and
-  `topology_uplinks()`'s docstring already names both. Synthesising a switch
-  that might be a hypervisor is inventing topology. Name the port, list the
-  clients, give both causes, point at `[[device]]` and `[[hosted]]`.
+  **Report it, and flag it, but never draw a node for it.** Several MACs on one
+  port means an unmanaged switch *or* a virtualisation host with bridged
+  guests, and `topology_uplinks()`'s docstring already names both. Synthesising
+  a switch that might be a hypervisor is inventing topology, so no node is ever
+  added for this. That line was drawn before the diagram gained any visible
+  signal at all; once one was added, "flag it" and "draw a node" turned out to
+  be different things, and only the second is still refused. `--report` names
+  the port and lists the clients, in a `SHARED SWITCH PORTS` section
+  (`diagnostics._shared_ports_section`); the diagram marks the same edges with
+  a plain `*` appended to the port label plus a legend note in the DOT/SVG/PDF/
+  PNG backend, and the label marker alone in draw.io, which has no legend at
+  all. `cmd_render` also warns on the console once per shared port
+  (`_hint_about_shared_ports`), obfuscation-aware like `_report_displacements`:
+  named normally, a bare count under `--obfuscate`. All four read from one
+  `Topology.shared_ports()`, restricted to direct `CLIENT_UPLINK` reports so a
+  `TOPOLOGY_GRAPH`-inferred edge (a step removed from what the port itself
+  said) never counts, and computed against the *final* topology so a
+  `[[hosted]]` override that reparents a client off the shared port already
+  resolves it rather than still flagging it.
+
+  A merged single line splitting into the several clients, proposed and
+  dropped in the same conversation this shipped in: it needs a real junction
+  node in the DOT graph (and the draw.io coordinate pass, since both share the
+  same staggered DOT), and a junction dot between a switch and its clients
+  reads as "there's a device here" exactly as much as a synthesised switch
+  would, for the same reason this section already refuses to draw one.
 
   Count only `Kind.WIRED_CLIENT`. Wireless clients share an AP by definition,
   the same reasoning that scoped KAN-129's count to clients.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1122,9 +1122,29 @@ stub generator to act on (KAN-120).
   be different things, and only the second is still refused. `--report` names
   the port and lists the clients, in a `SHARED SWITCH PORTS` section
   (`diagnostics._shared_ports_section`); the diagram marks the same edges with
-  a plain `*` appended to the port label plus a legend note in the DOT/SVG/PDF/
+  a plain `*` appended to the port label plus a legend row in the DOT/SVG/PDF/
   PNG backend, and the label marker alone in draw.io, which has no legend at
-  all. `cmd_render` also warns on the console once per shared port
+  all.
+
+  **The `*` alone shipped invisible in the default render, caught the same
+  day by external review.** `--layout unifi` is the default, and it suppresses
+  port labels entirely (`Style.show_port_labels`), because ortho routing
+  cannot place them without the text drifting onto unrelated nodes; it
+  suppresses the legend too. The `*` rides on the port label, so on the render
+  most people actually produce, both the marker and its legend row were gone
+  and the feature had no visible signal at all — it still detected, reported
+  and logged, just never drew. Fixed by giving the edge its own layout-
+  independent channel, `arrowhead=diamond`, unconditionally rather than gated
+  on `show_port_labels`, the same way `TOPOLOGY_GRAPH`'s `arrowhead=odot`
+  already was; the two never collide since `shared_ports()` only ever counts
+  direct `CLIENT_UPLINK` edges. The legend row is still gated on
+  `show_legend`, matching every other marker here (wireless dashing, asserted
+  dotting, the odot arrowhead) — `--layout unifi` omits the legend on purpose,
+  and this is not the marker to special-case that for. draw.io needed no
+  equivalent fix: it has no `show_port_labels` concept, so its `*` was never
+  gated in the first place.
+
+  `cmd_render` also warns on the console once per shared port
   (`_hint_about_shared_ports`), obfuscation-aware like `_report_displacements`:
   named normally, a bare count under `--obfuscate`. All four read from one
   `Topology.shared_ports()`, restricted to direct `CLIENT_UPLINK` reports so a

--- a/TODO.md
+++ b/TODO.md
@@ -54,13 +54,16 @@ drawn from a thin one look equally authoritative.
   **Several wired clients reporting the same switch and port. Shipped**,
   2026-08-16. Needs no cooperation from the hidden device, which is what makes
   it work where LLDP cannot. Flagged, not drawn as a node: the diagram marks
-  the shared edges with `*` on the port label plus a legend note (label only in
-  draw.io, which has no legend), `--report` names the port and lists the
-  clients in a `SHARED SWITCH PORTS` section, and the console warns once per
-  shared port (a bare count under `--obfuscate`). Several MACs on a port means
-  an unmanaged switch or a virtualisation host bridging its guests, and neither
-  the diagram nor the console picks one; `[[device]]` or `[[hosted]]` is how you
-  say which it actually is.
+  the shared edges with a small diamond arrowhead, present in every layout
+  including the default `unifi` (`--layout tree` additionally appends `*` to
+  the port label, and gets a legend row; draw.io gets the label marker alone,
+  since it has no legend). `--report` names the port and lists the clients in
+  a `SHARED SWITCH PORTS` section, and the console warns once per shared port
+  (a bare count under `--obfuscate`). Several MACs on a port means an
+  unmanaged switch or a virtualisation host bridging its guests, and neither
+  the diagram nor the console picks one; `[[device]]` or `[[hosted]]` is how
+  you say which it actually is. `unifi-map overrides generate` (KAN-120) now
+  prints a starting skeleton for exactly this case.
 
   **The controller's own `has_unknown_switch` boolean is still unread.** It
   says one exists somewhere, never where, so it complements the signal above

--- a/TODO.md
+++ b/TODO.md
@@ -150,12 +150,15 @@ drawn from a thin one look equally authoritative.
 
 ## Overrides
 
-- **A candidates generator** (KAN-120). Emit a skeleton overrides file seeded
-  from what `--report` found: what could not be placed, artwork refused as
-  ambiguous, ports that look like they have a hidden switch behind them.
-  Commented boilerplate that still requires a human to state the relationship;
-  never a guessed parent. The other half of that ticket, `overrides check`,
-  ships already.
+- **A candidates generator. Shipped**, as `unifi-map overrides generate`
+  (KAN-120), 2026-08-16. Prints a commented skeleton to stdout, seeded from
+  the same signals `--report` names: clients with no reported uplink, switch
+  ports shared by several wired clients (KAN-199), and artwork matches
+  refused as ambiguous. Every block is commented out, so the file changes
+  nothing until a human edits and uncomments it; the one field it never fills
+  in is a client's real uplink. `--report` now points at it from each of
+  those three sections. `overrides check`, the other half of the original
+  ticket, shipped earlier.
 
 ## Multi-site
 

--- a/TODO.md
+++ b/TODO.md
@@ -49,16 +49,25 @@ drawn from a thin one look equally authoritative.
   there is nothing wrong with a specific device and no overrides entry that
   would fix it.
 - **Say when something is hiding on a switch port** (KAN-199). Two signals, and
-  they are complementary. The controller's own v2 topology payload carries a
-  `has_unknown_switch` boolean that we do not read, which says one exists
-  somewhere but not where. Several wired clients reporting the same switch and
-  port says where, and needs no cooperation from the hidden device, which is
-  what makes it work where LLDP cannot.
+  they are complementary. Only one is built.
 
-  Reported rather than drawn: the signal is unambiguous and its cause is not,
-  since several MACs on a port means an unmanaged switch or a virtualisation
-  host bridging its guests. The report names the port and leaves the answer to
-  a `[[device]]` or `[[hosted]]` entry.
+  **Several wired clients reporting the same switch and port. Shipped**,
+  2026-08-16. Needs no cooperation from the hidden device, which is what makes
+  it work where LLDP cannot. Flagged, not drawn as a node: the diagram marks
+  the shared edges with `*` on the port label plus a legend note (label only in
+  draw.io, which has no legend), `--report` names the port and lists the
+  clients in a `SHARED SWITCH PORTS` section, and the console warns once per
+  shared port (a bare count under `--obfuscate`). Several MACs on a port means
+  an unmanaged switch or a virtualisation host bridging its guests, and neither
+  the diagram nor the console picks one; `[[device]]` or `[[hosted]]` is how you
+  say which it actually is.
+
+  **The controller's own `has_unknown_switch` boolean is still unread.** It
+  says one exists somewhere, never where, so it complements the signal above
+  rather than replacing it — but it is also unverified: whether it is per-site,
+  whether it clears, and whether an all-UniFi network ever sets it are all
+  still open questions. See `CLAUDE.md`'s KAN-199 notes before building this
+  half.
 
 ## More ways to look at the network
 

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -298,6 +298,36 @@ for would let a file pass here and fail there, which is the one outcome this
 command exists to prevent. If you render with `--show-offline yes`, check with
 it too.
 
+## Generating a starting point
+
+```bash
+unifi-map overrides generate > candidates.toml
+```
+
+Prints a commented skeleton to stdout, seeded from the same three things
+[`--report`](usage.md#how-much-to-trust-the-map---report) names: clients with
+no reported uplink, switch ports shared by several wired clients (a hint that
+an unmanaged switch or a virtualisation host is hiding there), and artwork
+matches refused as ambiguous.
+
+**Every block is commented out.** The file changes nothing until you edit and
+uncomment the parts you want, so it is safe to redirect straight to a file and
+read at your leisure rather than something you need to review line by line
+before it can touch anything.
+
+**The one thing it never fills in is a client's real uplink.** A `[[link]]`
+skeleton always has `from` set to the client's MAC (the one selector guaranteed
+unique) and `to = ""` left for you: guessing where a cable actually goes would
+be exactly the invented topology this whole file exists to avoid. A shared-port
+skeleton is more filled in, because less is actually unknown: the suggested
+device name and its `parent`/`port` are read straight off the map, and only
+whether the device is real is left to you, by choosing whether to uncomment it.
+
+Like `check`, this reads the cache and contacts no controller. Artwork
+ambiguity is resolved offline and best-effort, the same way `unifi-map shape`
+resolves it: only what is already cached counts, nothing is fetched, and a
+cold cache simply means that section is empty rather than the command failing.
+
 ## Where `note` shows up
 
 `note` behaves differently per block, which is worth stating because all four

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,7 @@ unifi-map fetch --support-file FILE.tgz     # or read a support file instead
 unifi-map render                           # render from the cached snapshot
 unifi-map render --per-network              # one diagram per client network
 unifi-map overrides check                   # validate overrides without rendering
+unifi-map overrides generate                # print a starting overrides.toml skeleton
 unifi-map shape                             # describe the network, for sharing
 unifi-map render --no-clients               # infrastructure only
 unifi-map render -f svg pdf drawio dot      # pick formats
@@ -151,8 +152,12 @@ thinner every time with nothing saying why:
 Then, where anything needs attention, it names the devices involved rather than
 only counting them: clients that could not be placed, clients with no address
 from any source, networks a client claims to be on that the controller does not
-list, and artwork matches [refused as ambiguous](artwork.md). A map with nothing
-wrong prints no device names at all, so a short report is a good sign.
+list, switch ports shared by several wired clients (a hint that an unmanaged
+switch or a virtualisation host is hiding there), and artwork matches
+[refused as ambiguous](artwork.md). A map with nothing wrong prints no device
+names at all, so a short report is a good sign. Where any of these apply,
+`unifi-map overrides generate` prints a commented starting point seeded from
+exactly what the report found.
 
 The counts are the point of the first section: how much of the map the
 controller reported directly versus filled in from a second endpoint versus
@@ -303,9 +308,13 @@ shape, or line style, so the diagram survives greyscale printing.
 | Wireless link | Dashed line |
 | Offline device | Dashed border, `OFFLINE` in the label |
 | Client placed via the topology graph, not its own uplink report | Small hollow circle at the child end of the link |
+| Switch port shared by several wired clients | Small diamond at the child end of the link, present in every layout |
 
 With `--layout tree`, edge labels are switch port numbers (`port 12`) or the
-radio for wireless clients.
+radio for wireless clients; a shared port additionally gets a trailing `*`
+(`port 12 *`). `--layout unifi` never shows port labels at all (ortho routing
+can't place them), which is why the diamond marker above doesn't depend on
+one.
 
 The legend only lists what a given render actually encodes. A node drawn as
 artwork has no border and no fill, so it carries no accent colour and gets no
@@ -337,7 +346,9 @@ the cable goes, and [manual overrides](overrides.md) are how you say so. A
 switch the controller cannot see either, `[[device]]` declares the switch first
 and the link hangs off it. Both are drawn dotted, so the map still distinguishes
 what you asserted from what the controller reported. The placeholder disappears
-once nothing is left under it.
+once nothing is left under it. [`unifi-map overrides
+generate`](overrides.md#generating-a-starting-point) prints a skeleton with the
+selectors already filled in, so you only have to say where they connect.
 
 `--report` lists exactly which clients ended up there, with their addresses and
 networks, which is usually enough to recognise them without opening the diagram.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -439,8 +439,8 @@ equivalent. Command options must follow the subcommand.
 
 | Flag | What it does | Default |
 | --- | --- | --- |
-| `action` `{check}` | check: apply the file against the cached snapshot and report, failing on any selector that matches nothing or several things |  |
+| `action` `{check,generate}` | check: apply the file against the cached snapshot and report, failing on any selector that matches nothing or several things. generate: print a commented overrides skeleton, seeded from what the cached snapshot could not resolve, to stdout |  |
 | `--show-offline` `{yes,no}` | Include devices the controller lists but that are not currently connected. Defaults to no, because a controller keeps remembering hardware long after it has been pulled from the rack; use yes when you want to see what it still thinks exists (default: no) | `no` |
-| `--overrides` | Which file to check. Defaults to overrides.toml when it exists. |  |
+| `--overrides` | Which file to check. Defaults to overrides.toml when it exists. Not used by generate. |  |
 
 <!-- END GENERATED FLAGS -->

--- a/src/unifi_map/cli.py
+++ b/src/unifi_map/cli.py
@@ -55,7 +55,7 @@ from .output import (
     warn_about_svg_artwork,
     write_outputs,
 )
-from .overrides import OverrideError
+from .overrides import OverrideError, generate_candidates
 from .overrides import apply as apply_overrides
 from .overrides import load as load_overrides
 from .progress import SpinnerAwareHandler, spinner
@@ -797,6 +797,12 @@ def _subtitle(tally: dict[str, int]) -> str:
 
 
 def cmd_overrides(args: argparse.Namespace) -> int:
+    if args.action == "generate":
+        return _cmd_overrides_generate(args)
+    return _cmd_overrides_check(args)
+
+
+def _cmd_overrides_check(args: argparse.Namespace) -> int:
     """Validate an overrides file without rendering anything.
 
     Overrides fail loudly by design: an unmatched or ambiguous selector stops
@@ -832,6 +838,28 @@ def cmd_overrides(args: argparse.Namespace) -> int:
     )
     if result.icons:
         log.info("  %d node(s) given artwork you supplied", len(result.icons))
+    return 0
+
+
+def _cmd_overrides_generate(args: argparse.Namespace) -> int:
+    """Print a commented overrides skeleton seeded from what this map could not resolve.
+
+    Printed to stdout rather than written anywhere, the same choice `shape`
+    makes: this never had an overwrite guard to design, and `> candidates.toml`
+    or a look before saving is the reader's call, not this command's.
+
+    Artwork resolution is offline and best-effort, the same as `shape`'s: only
+    whatever is already cached counts, nothing is fetched, and a lookup failure
+    must not stop this from printing what it did find. KAN-120.
+    """
+    snapshot = Snapshot.read(args.cache_dir)
+    topo = build_topology(snapshot, include_offline=args.show_offline == "yes")
+
+    store = AssetStore(cache_dir=args.asset_cache, offline=True)
+    with contextlib.suppress(Exception):
+        resolve_icons(topo, store, get_theme("light"), {})
+
+    print(generate_candidates(topo, list(store.ambiguous_names)), end="")
     return 0
 
 
@@ -1280,19 +1308,22 @@ def build_parser() -> argparse.ArgumentParser:
     overrides = sub.add_parser(
         "overrides",
         parents=[shared, offline_flag],
-        help="Check an overrides file without rendering",
+        help="Check an overrides file, or generate a skeleton, without rendering",
     )
     overrides.add_argument(
         "action",
-        choices=("check",),
+        choices=("check", "generate"),
         help="check: apply the file against the cached snapshot and report, "
-        "failing on any selector that matches nothing or several things",
+        "failing on any selector that matches nothing or several things. "
+        "generate: print a commented overrides skeleton, seeded from what the "
+        "cached snapshot could not resolve, to stdout",
     )
     overrides.add_argument(
         "--overrides",
         type=Path,
         default=argparse.SUPPRESS,
-        help=f"Which file to check. Defaults to {DEFAULT_OVERRIDES} when it exists.",
+        help=f"Which file to check. Defaults to {DEFAULT_OVERRIDES} when it exists. "
+        "Not used by generate.",
     )
     overrides.set_defaults(func=cmd_overrides)
 

--- a/src/unifi_map/cli.py
+++ b/src/unifi_map/cli.py
@@ -352,6 +352,43 @@ def _hint_about_unplaced(topo: Topology, overrides_path: Path | None) -> None:
     )
 
 
+def _hint_about_shared_ports(topo: Topology, obfuscated: bool) -> None:
+    """Warn when several wired clients report the same switch and port.
+
+    This is the console half of KAN-199; `render_dot`/`render_drawio` mark the
+    same thing on the diagram with a `*` on the port label, because which of
+    an unmanaged switch or a virtualisation host it is cannot be told apart
+    from here, and synthesising a node for either would be inventing topology.
+
+    Same obfuscation treatment as `_report_displacements`: naming the switch
+    and its clients here would be exactly the leak --obfuscate exists to
+    prevent, so an obfuscated run gets a count only.
+    """
+    groups = topo.shared_ports()
+    if not groups:
+        return
+    if obfuscated:
+        log.warning(
+            "%d switch port(s) report more than one wired client, which can "
+            "mean an unmanaged switch or a virtualisation host the controller "
+            "cannot see. Re-run without --obfuscate to see which.",
+            len(groups),
+        )
+        return
+    for (parent, port), macs in sorted(groups.items()):
+        switch = topo.nodes[parent].label
+        clients = ", ".join(topo.nodes[mac].label for mac in macs)
+        log.warning(
+            "%s, %s: %d wired clients share this port (%s). This can mean an "
+            "unmanaged switch or a virtualisation host the controller cannot "
+            "see; see docs/overrides.md for [[device]] and [[hosted]].",
+            switch,
+            port,
+            len(macs),
+            clients,
+        )
+
+
 def _stagger_for(topo: Topology, requested: int, style: Style) -> int:
     if requested <= 0 or not style.staggers:
         return 0
@@ -648,6 +685,7 @@ def cmd_render(args: argparse.Namespace) -> int:
     # After overrides, not before: the whole point is to report what is *still*
     # unplaced, and running first counts the clients an override just placed.
     _hint_about_unplaced(topo, path)
+    _hint_about_shared_ports(topo, args.obfuscate)
 
     # Only assembled when asked for: a normal render has no use for the tally.
     artwork_counts: dict[str, int] | None = {} if args.report else None

--- a/src/unifi_map/diagnostics.py
+++ b/src/unifi_map/diagnostics.py
@@ -152,7 +152,8 @@ def _unplaced_section(topo: Topology) -> list[str]:
         "COULD NOT BE PLACED",
         "  Neither stat/sta nor the controller's topology graph reported an uplink",
         "  for these, so they hang off a placeholder rather than a guessed parent.",
-        "  An overrides file is how you say where they really are; see",
+        "  An overrides file is how you say where they really are; run",
+        "  `unifi-map overrides generate` for a starting point, or see",
         "  docs/overrides.md.",
         "",
     ]
@@ -263,7 +264,8 @@ def _shared_ports_section(topo: Topology) -> list[str]:
         "SHARED SWITCH PORTS",
         "  More than one wired client reports the same switch and port. This can",
         "  mean an unmanaged switch or a virtualisation host bridging its guests",
-        "  that the controller cannot see. An overrides file can say which: see",
+        "  that the controller cannot see. An overrides file can say which; run",
+        "  `unifi-map overrides generate` for a starting point, or see",
         "  docs/overrides.md for [[device]] and [[hosted]].",
         "",
     ]
@@ -434,7 +436,8 @@ def _artwork_refused(ambiguous_artwork: list[tuple[str, int]]) -> list[str]:
         "ARTWORK REFUSED AS AMBIGUOUS",
         "  These names matched more than one product, so no artwork was used.",
         "  Refusing is deliberate: picking one would be inventing data. Rename",
-        "  the device in the console, or set an icon in an overrides file.",
+        "  the device in the console, or set an icon in an overrides file; run",
+        "  `unifi-map overrides generate` for a starting point.",
         "",
     ]
     for (name, matches), times in sorted(counted.items()):

--- a/src/unifi_map/diagnostics.py
+++ b/src/unifi_map/diagnostics.py
@@ -245,6 +245,37 @@ def _mac_randomisation_section(topo: Topology) -> list[str]:
     ]
 
 
+def _shared_ports_section(topo: Topology) -> list[str]:
+    """Switch ports where more than one wired client reports the same port.
+
+    Two causes look identical from here: an unmanaged switch the controller
+    cannot see, or a virtualisation host bridging its guests onto one NIC
+    (KAN-199). Reported rather than drawn, because synthesising a node for
+    either would be inventing topology this map has no basis for; the diagram
+    itself only marks the port with `*`, for the same reason. `[[device]]` or
+    `[[hosted]]` in an overrides file is how you say which it actually is.
+    """
+    groups = topo.shared_ports()
+    if not groups:
+        return []
+    out = [
+        "",
+        "SHARED SWITCH PORTS",
+        "  More than one wired client reports the same switch and port. This can",
+        "  mean an unmanaged switch or a virtualisation host bridging its guests",
+        "  that the controller cannot see. An overrides file can say which: see",
+        "  docs/overrides.md for [[device]] and [[hosted]].",
+        "",
+    ]
+    for (parent, port), macs in sorted(
+        groups.items(), key=lambda item: (topo.nodes[item[0][0]].label.lower(), item[0][1])
+    ):
+        clients = sorted((topo.nodes[mac] for mac in macs), key=lambda n: n.label.lower())
+        out.append(f"  {_describe(topo.nodes[parent])}, {port}")
+        out.extend(f"      {_describe(client)}" for client in clients)
+    return out
+
+
 def _dangling_networks(topo: Topology) -> list[str]:
     """Networks a client claims to be on that the controller does not list.
 
@@ -468,6 +499,7 @@ def build_diagnostics(
     out += _endpoints_section(payloads)
     out += _unplaced_section(topo)
     out += _addressless_section(topo)
+    out += _shared_ports_section(topo)
     out += _dangling_networks(topo)
     out += _mac_randomisation_section(topo)
     out += _artwork_section(sources)

--- a/src/unifi_map/model.py
+++ b/src/unifi_map/model.py
@@ -188,6 +188,28 @@ class Topology:
             tally[node.kind.value] = tally.get(node.kind.value, 0) + 1
         return tally
 
+    def shared_ports(self) -> dict[tuple[str, str], list[str]]:
+        """(switch id, port label) -> client ids, for ports with more than one.
+
+        Several wired clients reporting the same switch and port usually means
+        an unmanaged switch or a virtualisation host bridging its guests that
+        the controller cannot see (KAN-199) — it needs no cooperation from the
+        hidden device, unlike LLDP. Restricted to direct `CLIENT_UPLINK`
+        reports: a `TOPOLOGY_GRAPH`-inferred edge is a step removed from what
+        the port itself said, and an override that reparents a client under an
+        asserted `[[hosted]]` device already resolves the sharing, since that
+        edge is no longer a `CLIENT_UPLINK` onto the original port.
+        """
+        groups: dict[tuple[str, str], list[str]] = {}
+        for edge in self.edges:
+            if edge.provenance is not Provenance.CLIENT_UPLINK or edge.wireless or not edge.label:
+                continue
+            node = self.nodes.get(edge.src)
+            if node is None or node.kind is not Kind.WIRED_CLIENT:
+                continue
+            groups.setdefault((edge.dst, edge.label), []).append(edge.src)
+        return {key: macs for key, macs in groups.items() if len(macs) > 1}
+
 
 def _classify(device: dict[str, Any]) -> Kind:
     raw = str(device.get("type") or "").lower()

--- a/src/unifi_map/overrides.py
+++ b/src/unifi_map/overrides.py
@@ -706,6 +706,33 @@ def apply(topo: Topology, overrides: Overrides, cache_dir: Path | None = None) -
     return result
 
 
+def _comment_safe(text: str) -> str:
+    """Collapse whitespace so *text* cannot break out of a `#` comment line.
+
+    A newline ends the line it sits on, and everything after it stops being a
+    comment -- the exact "inert until edited" guarantee this generator exists
+    to keep. Node and edge labels come from a controller, or worse a support
+    file, both hostile input by this project's own threat model throughout.
+    Same technique as `render_mermaid._flatten()`.
+    """
+    return " ".join(text.split())
+
+
+def _toml_value(text: str) -> str:
+    """*text*, safe to sit inside a commented `"..."` TOML string.
+
+    Applies `_comment_safe` first -- a TOML basic string cannot contain a
+    literal newline either, and breaking out of the comment is the more
+    serious of the two hazards -- then escapes the backslash and the quote
+    that would otherwise end the string early or corrupt it once the
+    surrounding block is uncommented. Found by external review: an
+    unescaped switch label containing a `"` produced `name = "...Core
+    "A")"`, invalid TOML the moment somebody acted on the suggestion.
+    """
+    safe = _comment_safe(text)
+    return safe.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _unplaced_candidates(topo: Topology) -> list[str]:
     """`[[link]]` skeletons for clients hanging off the placeholder."""
     stranded = sorted(
@@ -727,7 +754,7 @@ def _unplaced_candidates(topo: Topology) -> list[str]:
     for node in stranded:
         lines += [
             "# [[link]]",
-            f'# from = "{node.id}"  # {node.label}',
+            f'# from = "{_toml_value(node.id)}"  # {_comment_safe(node.label)}',
             '# to = ""  # TODO: what is this actually plugged into?',
             "",
         ]
@@ -766,18 +793,18 @@ def _shared_port_candidates(topo: Topology) -> list[str]:
         name = f"Unmanaged switch ({port} on {switch.label})"
         lines += [
             "# [[device]]",
-            f'# name = "{name}"',
+            f'# name = "{_toml_value(name)}"',
             '# kind = "switch"',
-            f'# parent = "{switch.id}"  # {switch.label}',
-            f'# port = "{_port_number(port)}"',
+            f'# parent = "{_toml_value(switch.id)}"  # {_comment_safe(switch.label)}',
+            f'# port = "{_toml_value(_port_number(port))}"',
             "",
         ]
         for mac in sorted(macs, key=lambda m: topo.nodes[m].label.lower()):
             client = topo.nodes[mac]
             lines += [
                 "# [[hosted]]",
-                f'# guest = "{client.id}"  # {client.label}',
-                f'# host = "{name}"',
+                f'# guest = "{_toml_value(client.id)}"  # {_comment_safe(client.label)}',
+                f'# host = "{_toml_value(name)}"',
                 "",
             ]
     return lines
@@ -812,7 +839,7 @@ def _artwork_candidates(topo: Topology, ambiguous_artwork: list[tuple[str, int]]
             seen.add(node.id)
             lines += [
                 "# [[node]]",
-                f'# match = "{node.id}"  # {node.label}',
+                f'# match = "{_toml_value(node.id)}"  # {_comment_safe(node.label)}',
                 f'# icon = ""  # TODO: path to artwork ({count} catalogue matches)',
                 "",
             ]

--- a/src/unifi_map/overrides.py
+++ b/src/unifi_map/overrides.py
@@ -704,3 +704,163 @@ def apply(topo: Topology, overrides: Overrides, cache_dir: Path | None = None) -
     _prune_placeholder(working)
     _refuse_cycles(working)
     return result
+
+
+def _unplaced_candidates(topo: Topology) -> list[str]:
+    """`[[link]]` skeletons for clients hanging off the placeholder."""
+    stranded = sorted(
+        (
+            topo.nodes[e.src]
+            for e in topo.edges
+            if e.dst == UNKNOWN_UPLINK_ID and e.src in topo.nodes
+        ),
+        key=lambda n: n.label.lower(),
+    )
+    if not stranded:
+        return []
+    lines = [
+        "# --- Clients with no reported uplink " + "-" * 37,
+        "# Neither stat/sta nor the controller's topology graph said where these",
+        "# are plugged in. Fill in `to` with the real parent's MAC, IP or label.",
+        "",
+    ]
+    for node in stranded:
+        lines += [
+            "# [[link]]",
+            f'# from = "{node.id}"  # {node.label}',
+            '# to = ""  # TODO: what is this actually plugged into?',
+            "",
+        ]
+    return lines
+
+
+def _port_number(port_label: str) -> str:
+    """`"port 7"` -> `"7"`. Model.py always builds the label this way for a
+    wired client edge; anything else is passed through unchanged."""
+    prefix = "port "
+    return port_label[len(prefix) :] if port_label.startswith(prefix) else port_label
+
+
+def _shared_port_candidates(topo: Topology) -> list[str]:
+    """`[[device]]` + `[[hosted]]` skeletons for KAN-199's shared-port signal.
+
+    The device's name is a suggested label, not a guessed identity: nothing
+    here is active until the block is uncommented, which is the human's own
+    assertion that the device actually exists. The one thing this never fills
+    in is which real device it is -- that stays entirely up to the reader.
+    """
+    groups = topo.shared_ports()
+    if not groups:
+        return []
+    lines = [
+        "# --- Switch ports shared by several wired clients " + "-" * 24,
+        "# This usually means an unmanaged switch or a virtualisation host the",
+        "# controller cannot see. Declare it below and say these clients are",
+        "# hosted on it -- or delete the block if it's something else.",
+        "",
+    ]
+    for (parent, port), macs in sorted(
+        groups.items(), key=lambda item: (topo.nodes[item[0][0]].label.lower(), item[0][1])
+    ):
+        switch = topo.nodes[parent]
+        name = f"Unmanaged switch ({port} on {switch.label})"
+        lines += [
+            "# [[device]]",
+            f'# name = "{name}"',
+            '# kind = "switch"',
+            f'# parent = "{switch.id}"  # {switch.label}',
+            f'# port = "{_port_number(port)}"',
+            "",
+        ]
+        for mac in sorted(macs, key=lambda m: topo.nodes[m].label.lower()):
+            client = topo.nodes[mac]
+            lines += [
+                "# [[hosted]]",
+                f'# guest = "{client.id}"  # {client.label}',
+                f'# host = "{name}"',
+                "",
+            ]
+    return lines
+
+
+def _artwork_candidates(topo: Topology, ambiguous_artwork: list[tuple[str, int]]) -> list[str]:
+    """`[[node]]` skeletons for catalogue matches refused as ambiguous.
+
+    *ambiguous_artwork* is `AssetStore.ambiguous_names`: `(node.label, how many
+    catalogue entries matched)`, recorded because `sysid_for_name()` only
+    resolves a name that matches exactly one entry. Matched back to a node by
+    label, since that is what was actually looked up; a label is not unique, so
+    every node carrying it is offered.
+    """
+    if not ambiguous_artwork:
+        return []
+    by_label: dict[str, list[Node]] = {}
+    for node in topo.nodes.values():
+        by_label.setdefault(node.label, []).append(node)
+
+    lines = [
+        "# --- Artwork matches refused as ambiguous " + "-" * 32,
+        "# The catalogue matched more than one product for these, so nothing was",
+        "# drawn rather than guessing. Point `icon` at artwork of your own.",
+        "",
+    ]
+    seen: set[str] = set()
+    for name, count in sorted(ambiguous_artwork):
+        for node in sorted(by_label.get(name, []), key=lambda n: n.id):
+            if node.id in seen:
+                continue
+            seen.add(node.id)
+            lines += [
+                "# [[node]]",
+                f'# match = "{node.id}"  # {node.label}',
+                f'# icon = ""  # TODO: path to artwork ({count} catalogue matches)',
+                "",
+            ]
+    return lines
+
+
+def generate_candidates(
+    topo: Topology, ambiguous_artwork: list[tuple[str, int]] | None = None
+) -> str:
+    """A commented overrides skeleton seeded from what this map could not resolve.
+
+    Every block is commented out, so the file is inert until edited: loading it
+    unmodified changes nothing. That is deliberate and matches the rest of this
+    module -- this never guesses a parent, an identity or a hidden device's
+    existence, it only names where the map has a gap and gives a starting point
+    with the selectors already filled in, since a MAC is always unambiguous and
+    typing one out by hand is exactly the kind of transcription a tool should do
+    instead of a person.
+    """
+    sections = [
+        section
+        for section in (
+            _unplaced_candidates(topo),
+            _shared_port_candidates(topo),
+            _artwork_candidates(topo, ambiguous_artwork or []),
+        )
+        if section
+    ]
+    header = [
+        "# Candidate overrides, generated by `unifi-map overrides generate`.",
+        "#",
+        "# Nothing here is active: every block below is commented out. Uncomment",
+        "# and fill in the blanks for the ones you want, save it, and point",
+        "# --overrides at the file. See docs/overrides.md.",
+    ]
+    if not sections:
+        return (
+            "\n".join(
+                [
+                    *header,
+                    "",
+                    "# Nothing to suggest: no unplaced clients, no shared switch ports,",
+                    "# and no ambiguous artwork matches on this map.",
+                ]
+            )
+            + "\n"
+        )
+    out = list(header)
+    for section in sections:
+        out += ["", *section]
+    return "\n".join(out).rstrip() + "\n"

--- a/src/unifi_map/render_dot.py
+++ b/src/unifi_map/render_dot.py
@@ -282,10 +282,11 @@ def _edge_lines(topo: Topology, style: Style) -> list[str]:
         if edge.src not in topo.nodes or edge.dst not in topo.nodes:
             continue
         attrs = []
+        group = shared.get((edge.dst, edge.label)) if edge.label else None
+        is_shared = bool(group and edge.src in group)
         if edge.label and style.show_port_labels:
             label_text = edge.label
-            group = shared.get((edge.dst, edge.label))
-            if group and edge.src in group:
+            if is_shared:
                 # Several clients on this port: flag it rather than draw a
                 # synthetic switch, since a hidden switch and a hypervisor
                 # bridging its guests look identical from here (KAN-199).
@@ -304,6 +305,13 @@ def _edge_lines(topo: Topology, style: Style) -> list[str]:
             # itself said. Independent of the line style above, so it composes
             # with a wireless edge instead of competing for the same channel.
             attrs.append("arrowhead=odot")
+        elif is_shared:
+            # Independent of the `*` on the label above, and deliberately not
+            # gated on `show_port_labels`: `--layout unifi`, the default,
+            # suppresses port labels entirely (ortho routing can't place them),
+            # so without its own channel this signal would be invisible in the
+            # one render most people actually produce.
+            attrs.append("arrowhead=diamond")
         suffix = f" [{', '.join(attrs)}]" if attrs else ""
         # Emitted parent -> child, the reverse of how edges are stored, so the
         # root lands at the top (rankdir=TB) or the left (rankdir=LR) instead of
@@ -436,16 +444,18 @@ def _legend_link_rows(topo: Topology, theme: Theme) -> list[str]:
         link_styles.append((". . .", "Stated in overrides"))
     if any(e.provenance is Provenance.TOPOLOGY_GRAPH for e in topo.edges):
         link_styles.append(("&#9472;&#9675;", "Inferred from the topology graph"))
+    if topo.shared_ports():
+        # The arrowhead marker (KAN-199), not the `*` on the port label: the
+        # label is suppressed in `--layout unifi`, but this row can still show
+        # up there, since `show_legend` follows the same layout switch rather
+        # than something narrower.
+        link_styles.append(("&#9472;&#9670;", "Shared switch port (possibly a hidden switch)"))
     for glyph, label in link_styles:
         rows.append(
             f'<TR><TD ALIGN="RIGHT"><FONT POINT-SIZE="10" COLOR="{theme.edge}" '
             f'FACE="{FONT}">{glyph}</FONT></TD>'
             f'<TD ALIGN="LEFT"><FONT POINT-SIZE="10" COLOR="{theme.text_muted}" '
             f'FACE="{FONT}">{label}</FONT></TD></TR>'
-        )
-    if topo.shared_ports():
-        rows.append(
-            _legend_note(theme, "* Multiple clients share a port: possibly a hidden switch.")
         )
     return rows
 

--- a/src/unifi_map/render_dot.py
+++ b/src/unifi_map/render_dot.py
@@ -277,12 +277,20 @@ def _node_lines(
 
 def _edge_lines(topo: Topology, style: Style) -> list[str]:
     lines = []
+    shared = topo.shared_ports()
     for edge in topo.edges:
         if edge.src not in topo.nodes or edge.dst not in topo.nodes:
             continue
         attrs = []
         if edge.label and style.show_port_labels:
-            attrs.append(f'label="{_escape(edge.label)}"')
+            label_text = edge.label
+            group = shared.get((edge.dst, edge.label))
+            if group and edge.src in group:
+                # Several clients on this port: flag it rather than draw a
+                # synthetic switch, since a hidden switch and a hypervisor
+                # bridging its guests look identical from here (KAN-199).
+                label_text += " *"
+            attrs.append(f'label="{_escape(label_text)}"')
         if edge.asserted:
             # Dotted means "you told me this", so it never reads as something
             # the controller reported.
@@ -434,6 +442,10 @@ def _legend_link_rows(topo: Topology, theme: Theme) -> list[str]:
             f'FACE="{FONT}">{glyph}</FONT></TD>'
             f'<TD ALIGN="LEFT"><FONT POINT-SIZE="10" COLOR="{theme.text_muted}" '
             f'FACE="{FONT}">{label}</FONT></TD></TR>'
+        )
+    if topo.shared_ports():
+        rows.append(
+            _legend_note(theme, "* Multiple clients share a port: possibly a hidden switch.")
         )
     return rows
 

--- a/src/unifi_map/render_drawio.py
+++ b/src/unifi_map/render_drawio.py
@@ -212,13 +212,20 @@ def _add_edge_cell(
     index: int,
     theme: Theme,
     routes: dict[tuple[str, str], list[list[tuple[float, float]]]],
+    shared: dict[tuple[str, str], list[str]],
 ) -> None:
     source, target = _cell_id(edge.dst), _cell_id(edge.src)
+    label_text = edge.label or ""
+    group = shared.get((edge.dst, edge.label)) if edge.label else None
+    if group and edge.src in group:
+        # Same marker as the DOT/SVG renderer: several clients on this port,
+        # flagged rather than drawn as a synthetic switch (KAN-199).
+        label_text += " *"
     cell = ET.SubElement(
         root,
         "mxCell",
         id=f"e{index}",
-        value=_text(edge.label or ""),
+        value=_text(label_text),
         style=_edge_style(edge, theme),
         edge="1",
         parent="1",
@@ -248,9 +255,10 @@ def _add_edge_cells(root: ET.Element, topo: Topology, layout: Layout, theme: The
     # Graphviz reported a route per edge; consumed in order, because two nodes
     # can be joined more than once and the nth here is the nth there.
     routes = {pair: list(paths) for pair, paths in layout.edges.items()}
+    shared = topo.shared_ports()
     for index, edge in enumerate(topo.edges):
         if edge.src in topo.nodes and edge.dst in topo.nodes:
-            _add_edge_cell(root, edge, index, theme, routes)
+            _add_edge_cell(root, edge, index, theme, routes, shared)
 
 
 def render_drawio(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -197,6 +197,34 @@ class TestItNamesWhatWentWrong:
         text = build_diagnostics(build_topology(snapshot))
         assert "NETWORKS NOT IN THE CONTROLLER'S LIST" not in text
 
+    def test_a_shared_switch_port_is_named_with_both_clients(
+        self, devices: dict, clients: dict, networkconf: dict
+    ):
+        """KAN-199: several wired clients on one port hints at a hidden switch."""
+        for i, name in enumerate(("printer", "camera")):
+            clients["data"].append(
+                {
+                    "mac": f"dd:ee:ff:00:00:8{i}",
+                    "hostname": name,
+                    "is_wired": True,
+                    "sw_mac": SWITCH_MAC,
+                    "sw_port": 7,
+                    "network_id": "net1",
+                }
+            )
+        snap = Snapshot(
+            payloads={"device": devices, "client_active": clients, "networkconf": networkconf}
+        )
+        text = build_diagnostics(build_topology(snap))
+        assert "SHARED SWITCH PORTS" in text
+        assert "port 7" in text
+        assert "printer" in text
+        assert "camera" in text
+        assert "[[hosted]]" in text
+
+    def test_no_shared_ports_section_when_every_port_has_one_client(self, snapshot: Snapshot):
+        assert "SHARED SWITCH PORTS" not in build_diagnostics(build_topology(snapshot))
+
 
 class TestWhatTheSnapshotCarries:
     """An optional endpoint that failed is logged once at fetch time and then

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -103,6 +103,7 @@ class TestItNamesWhatWentWrong:
         assert "COULD NOT BE PLACED" in text
         assert "mystery-box" in text
         assert "10.0.20.12" in text
+        assert "overrides generate" in text
 
     def test_no_unplaced_section_when_everything_resolves(self, snapshot: Snapshot):
         assert "COULD NOT BE PLACED" not in build_diagnostics(build_topology(snapshot))
@@ -221,6 +222,7 @@ class TestItNamesWhatWentWrong:
         assert "printer" in text
         assert "camera" in text
         assert "[[hosted]]" in text
+        assert "overrides generate" in text
 
     def test_no_shared_ports_section_when_every_port_has_one_client(self, snapshot: Snapshot):
         assert "SHARED SWITCH PORTS" not in build_diagnostics(build_topology(snapshot))
@@ -291,6 +293,7 @@ class TestArtwork:
         assert "ARTWORK REFUSED AS AMBIGUOUS" in text
         assert "g3-flex" in text
         assert "matched 2 catalogue entries" in text
+        assert "overrides generate" in text
 
     def test_a_name_ambiguous_several_times_is_counted_once_with_a_multiplier(self):
         sources = Sources(ambiguous_artwork=[("g3-flex", 2), ("g3-flex", 2)])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,8 +5,11 @@ import pytest
 from unifi_map.client import Snapshot, unwrap
 from unifi_map.model import (
     UNKNOWN_UPLINK_ID,
+    Edge,
     Kind,
+    Node,
     Provenance,
+    Topology,
     build_fingerprints,
     build_topology,
     client_networks,
@@ -724,3 +727,52 @@ class TestProvenance:
             assert node.asserted == (node.provenance is Provenance.OVERRIDE), node.id
         for edge in topo.edges:
             assert edge.asserted == (edge.provenance is Provenance.OVERRIDE), (edge.src, edge.dst)
+
+
+class TestSharedPorts:
+    """KAN-199: several wired clients on one switch port hint at a hidden switch."""
+
+    def _topo(self):
+        topo = Topology()
+        topo.add(Node(id="sw", label="switch", kind=Kind.SWITCH))
+        topo.add(Node(id="c1", label="c1", kind=Kind.WIRED_CLIENT))
+        topo.add(Node(id="c2", label="c2", kind=Kind.WIRED_CLIENT))
+        topo.edges.append(
+            Edge(src="c1", dst="sw", label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        topo.edges.append(
+            Edge(src="c2", dst="sw", label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        return topo
+
+    def test_two_clients_on_one_port_are_grouped(self):
+        topo = self._topo()
+        groups = topo.shared_ports()
+        assert groups == {("sw", "port 7"): ["c1", "c2"]}
+
+    def test_a_single_client_on_a_port_is_not_flagged(self):
+        topo = self._topo()
+        topo.edges.pop()
+        assert topo.shared_ports() == {}
+
+    def test_different_ports_are_not_grouped_together(self):
+        topo = self._topo()
+        topo.edges[-1].label = "port 8"
+        assert topo.shared_ports() == {}
+
+    def test_a_topology_graph_inferred_edge_does_not_count(self):
+        """An inferred uplink is a step removed from what the port itself said."""
+        topo = self._topo()
+        topo.edges[-1].provenance = Provenance.TOPOLOGY_GRAPH
+        assert topo.shared_ports() == {}
+
+    def test_a_wireless_edge_does_not_count(self):
+        topo = self._topo()
+        topo.edges[-1].wireless = True
+        assert topo.shared_ports() == {}
+
+    def test_an_override_that_reparents_a_client_resolves_the_sharing(self):
+        """Once `[[hosted]]` moves a client off the shared port, it's explained."""
+        topo = self._topo()
+        topo.edges[-1] = Edge(src="c2", dst="c1", provenance=Provenance.OVERRIDE, asserted=True)
+        assert topo.shared_ports() == {}

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -6,6 +6,7 @@ stub is not untested dead code.
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -864,3 +865,101 @@ class TestGenerateCandidates:
         for line in text.splitlines():
             if line.strip():
                 assert line.startswith("#"), f"uncommented line: {line!r}"
+
+
+class TestGenerateCandidatesEscaping:
+    """Found by external review of cfcd2fe: a controller-supplied label
+
+    containing a `"` produced invalid TOML the moment the suggested block was
+    uncommented, and a label containing a newline broke out of the `#`
+    comment entirely -- both violate "inert until edited", the one promise
+    this generator makes. Labels are hostile input by this project's own
+    threat model throughout, controller or (worse) support-file supplied.
+    """
+
+    def _uncommented_block(self, text: str, opening: str) -> str:
+        """Strip the leading `# ` from one `# [[block]]` ... blank-line run,
+        so it can be fed to `tomllib` as real TOML. *opening* is e.g.
+        `"[[device]]"`; the generated line itself is `"# [[device]]"`."""
+        lines = text.splitlines()
+        start = next(i for i, line in enumerate(lines) if line.strip() == f"# {opening}")
+        block = []
+        for line in lines[start:]:
+            if not line.strip():
+                break
+            block.append(line.removeprefix("# ").removeprefix("#"))
+        return "\n".join(block)
+
+    def _shared_port_topo(self, switch_label: str):
+        topo = Topology()
+        topo.add(Node(id=SWITCH_MAC, label=switch_label, kind=Kind.SWITCH))
+        topo.add(Node(id="c1", label="printer", kind=Kind.WIRED_CLIENT))
+        topo.add(Node(id="c2", label="camera", kind=Kind.WIRED_CLIENT))
+        topo.edges.append(
+            Edge(src="c1", dst=SWITCH_MAC, label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        topo.edges.append(
+            Edge(src="c2", dst=SWITCH_MAC, label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        return topo
+
+    def test_a_quoted_switch_label_produces_valid_toml(self):
+        text = generate_candidates(self._shared_port_topo('Core "A"'))
+        device_toml = self._uncommented_block(text, "[[device]]")
+        parsed = tomllib.loads(device_toml)
+        assert parsed["device"][0]["name"] == 'Unmanaged switch (port 7 on Core "A")'
+
+    def test_a_backslash_in_a_switch_label_produces_valid_toml(self):
+        text = generate_candidates(self._shared_port_topo(r"Core\A"))
+        device_toml = self._uncommented_block(text, "[[device]]")
+        parsed = tomllib.loads(device_toml)
+        assert parsed["device"][0]["name"] == r"Unmanaged switch (port 7 on Core\A)"
+
+    def test_a_newline_in_a_switch_label_cannot_escape_the_comment(self):
+        """The severe case: a raw newline would otherwise end the `#` line
+        and let attacker-controlled text be read as real TOML, uncommented
+        and unreviewed, the moment somebody ran `overrides check`."""
+        text = generate_candidates(self._shared_port_topo("Core\nrogue = 1"))
+        for line in text.splitlines():
+            if line.strip():
+                assert line.startswith("#"), f"uncommented line: {line!r}"
+        # The injected key must not have landed as a real top-level line either.
+        assert not tomllib.loads("\n".join(text.splitlines()))
+
+    def test_a_quoted_client_id_in_a_hosted_block_produces_valid_toml(self):
+        """`id` is normally a MAC, but `_norm_mac` never validates its shape,
+        and a support file's fields are attacker-controlled by this
+        project's own threat model. The `guest =`/`host =` values it feeds
+        are the ones actually inside quotes, unlike the trailing `# label`
+        comment, which tolerates a quote just fine either way."""
+        topo = self._shared_port_topo("switch")
+        del topo.nodes["c1"]
+        # Sorts before "camera" alphabetically, so it lands in the first
+        # [[hosted]] block this test's helper grabs.
+        topo.add(Node(id='c1"; x', label="aaa-printer", kind=Kind.WIRED_CLIENT))
+        topo.edges[0] = Edge(
+            src='c1"; x', dst=SWITCH_MAC, label="port 7", provenance=Provenance.CLIENT_UPLINK
+        )
+        text = generate_candidates(topo)
+        hosted_toml = self._uncommented_block(text, "[[hosted]]")
+        parsed = tomllib.loads(hosted_toml)
+        assert parsed["hosted"][0]["guest"] == 'c1"; x'
+
+    def test_a_quoted_unplaced_client_id_produces_valid_toml(self):
+        topo = Topology()
+        topo.add(Node(id="gw", label="gateway", kind=Kind.GATEWAY))
+        topo.add(Node(id='dd:ee:ff"; x', label="vm-host", kind=Kind.WIRED_CLIENT))
+        topo.add(Node(id=UNKNOWN_UPLINK_ID, label="Uplink not reported", kind=Kind.UNKNOWN))
+        topo.edges.append(Edge(src='dd:ee:ff"; x', dst=UNKNOWN_UPLINK_ID))
+        text = generate_candidates(topo)
+        link_toml = self._uncommented_block(text, "[[link]]")
+        parsed = tomllib.loads(link_toml)
+        assert parsed["link"][0]["from"] == 'dd:ee:ff"; x'
+
+    def test_a_quoted_ambiguous_id_produces_valid_toml(self):
+        topo = Topology()
+        topo.add(Node(id='dd:ee:ff"; x', label="thing", kind=Kind.WIRED_CLIENT))
+        text = generate_candidates(topo, ambiguous_artwork=[("thing", 2)])
+        node_toml = self._uncommented_block(text, "[[node]]")
+        parsed = tomllib.loads(node_toml)
+        assert parsed["node"][0]["match"] == 'dd:ee:ff"; x'

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -12,7 +12,15 @@ import pytest
 
 from unifi_map.assets import AssetError
 from unifi_map.client import Snapshot
-from unifi_map.model import UNKNOWN_UPLINK_ID, Edge, Kind, Node, Topology, build_topology
+from unifi_map.model import (
+    UNKNOWN_UPLINK_ID,
+    Edge,
+    Kind,
+    Node,
+    Provenance,
+    Topology,
+    build_topology,
+)
 from unifi_map.overrides import (
     Hosted,
     Link,
@@ -20,6 +28,7 @@ from unifi_map.overrides import (
     Overrides,
     _refuse_cycles,
     apply,
+    generate_candidates,
     load,
     parse,
     resolve,
@@ -787,3 +796,71 @@ class TestUnknownSections:
 
     def test_the_real_sections_still_parse(self):
         assert parse({"link": [{"from": "a", "to": "b"}]}).links
+
+
+class TestGenerateCandidates:
+    """KAN-120: a commented overrides skeleton seeded from what could not resolve.
+
+    Nothing here is a guessed parent or a guessed identity: every block is
+    commented out, and the one field this must never fill in (a client's real
+    uplink) is always left as an explicit TODO.
+    """
+
+    def test_a_clean_topology_says_so(self, topo):
+        assert "Nothing to suggest" in generate_candidates(topo)
+
+    def test_unplaced_clients_get_a_link_skeleton(self, unplaced_topo):
+        text = generate_candidates(unplaced_topo)
+        assert "[[link]]" in text
+        assert 'from = "dd:ee:ff:00:00:60"' in text
+        assert "vm-host" in text
+        # The one thing this must never guess.
+        assert 'to = ""' in text
+
+    def _shared_port_topo(self):
+        topo = Topology()
+        topo.add(Node(id=SWITCH_MAC, label="switch", kind=Kind.SWITCH))
+        topo.add(Node(id="c1", label="printer", kind=Kind.WIRED_CLIENT))
+        topo.add(Node(id="c2", label="camera", kind=Kind.WIRED_CLIENT))
+        topo.edges.append(
+            Edge(src="c1", dst=SWITCH_MAC, label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        topo.edges.append(
+            Edge(src="c2", dst=SWITCH_MAC, label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        return topo
+
+    def test_shared_ports_get_a_device_and_hosted_skeleton(self):
+        text = generate_candidates(self._shared_port_topo())
+        assert "[[device]]" in text
+        assert f'parent = "{SWITCH_MAC}"' in text
+        assert 'port = "7"' in text
+        assert "[[hosted]]" in text
+        assert 'guest = "c1"' in text
+        assert 'guest = "c2"' in text
+        # Both clients point at the same suggested device name.
+        assert text.count('host = "Unmanaged switch (port 7 on switch)"') == 2
+
+    def test_a_single_client_on_a_port_gets_no_shared_port_skeleton(self):
+        topo = self._shared_port_topo()
+        topo.edges.pop()
+        text = generate_candidates(topo)
+        assert "[[device]]" not in text
+
+    def test_ambiguous_artwork_gets_a_node_skeleton(self, topo):
+        label = next(n.label for n in topo.nodes.values())
+        node_id = next(n.id for n in topo.nodes.values() if n.label == label)
+        text = generate_candidates(topo, ambiguous_artwork=[(label, 3)])
+        assert "[[node]]" in text
+        assert f'match = "{node_id}"' in text
+        assert "3 catalogue matches" in text
+
+    def test_no_ambiguous_artwork_section_without_matches(self, topo):
+        assert "[[node]]" not in generate_candidates(topo, ambiguous_artwork=[])
+
+    def test_every_line_is_commented(self, unplaced_topo):
+        """The file must be a no-op until a human edits it."""
+        text = generate_candidates(unplaced_topo)
+        for line in text.splitlines():
+            if line.strip():
+                assert line.startswith("#"), f"uncommented line: {line!r}"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -97,6 +97,36 @@ def test_topology_graph_marker_composes_with_wireless_dashing():
     assert "style=dashed" in inferred
 
 
+def _topo_with_shared_port(shared: bool = True):
+    from unifi_map.model import Edge, Kind, Node, Provenance, Topology
+
+    topo = Topology()
+    topo.add(Node(id="sw", label="switch", kind=Kind.SWITCH, provenance=Provenance.DEVICE))
+    topo.add(Node(id="c1", label="c1", kind=Kind.WIRED_CLIENT, provenance=Provenance.CLIENT))
+    topo.edges.append(Edge(src="c1", dst="sw", label="port 7", provenance=Provenance.CLIENT_UPLINK))
+    if shared:
+        topo.add(Node(id="c2", label="c2", kind=Kind.WIRED_CLIENT, provenance=Provenance.CLIENT))
+        topo.edges.append(
+            Edge(src="c2", dst="sw", label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+    return topo
+
+
+def test_a_shared_port_gets_an_asterisk_on_both_edges():
+    """KAN-199: several clients on one port is flagged, never drawn as a node."""
+    dot_source = render_dot(_topo_with_shared_port(), "t", TREE)
+    lines = [line for line in dot_source.splitlines() if '"n_sw" -> "n_c' in line]
+    assert len(lines) == 2
+    assert all('label="port 7 *"' in line for line in lines)
+
+
+def test_an_unshared_port_gets_no_asterisk():
+    dot_source = render_dot(_topo_with_shared_port(shared=False), "t", TREE)
+    line = next(line for line in dot_source.splitlines() if '"n_sw" -> "n_c1"' in line)
+    assert 'label="port 7"' in line
+    assert "*" not in line
+
+
 def test_mac_colons_are_stripped_from_dot_identifiers(snapshot: Snapshot):
     dot_source = render_dot(build_topology(snapshot), "t", TREE)
     # A raw colon in an identifier would parse as a DOT port specifier.
@@ -361,6 +391,39 @@ class TestUnplacedClientsAreExplained:
         assert "2 client(s)" in " ".join(r.getMessage() for r in caplog.records)
 
 
+class TestSharedPortsAreExplained:
+    """The console half of KAN-199: `_hint_about_shared_ports`."""
+
+    def test_it_names_the_switch_port_and_clients(self, caplog):
+        from unifi_map.cli import _hint_about_shared_ports
+
+        with caplog.at_level("WARNING"):
+            _hint_about_shared_ports(_topo_with_shared_port(), obfuscated=False)
+        message = " ".join(r.getMessage() for r in caplog.records)
+        assert "switch" in message
+        assert "port 7" in message
+        assert "c1" in message and "c2" in message
+        assert "hosted" in message
+
+    def test_it_says_nothing_when_no_port_is_shared(self, caplog):
+        from unifi_map.cli import _hint_about_shared_ports
+
+        with caplog.at_level("WARNING"):
+            _hint_about_shared_ports(_topo_with_shared_port(shared=False), obfuscated=False)
+        assert not caplog.records
+
+    def test_obfuscated_runs_get_a_count_without_names(self, caplog):
+        from unifi_map.cli import _hint_about_shared_ports
+
+        with caplog.at_level("WARNING"):
+            _hint_about_shared_ports(_topo_with_shared_port(), obfuscated=True)
+        message = " ".join(r.getMessage() for r in caplog.records)
+        assert "1 switch port" in message
+        assert "c1" not in message
+        assert "c2" not in message
+        assert "--obfuscate" in message
+
+
 class TestSiteSelection:
     """`--site` exists so a script can loop over sites without re-exporting.
 
@@ -476,6 +539,12 @@ class TestLegendHonesty:
 
         topo = _topo_with_topology_graph_edge()
         assert "Inferred from the topology graph" in self._legend_text(topo, TREE)
+
+    def test_shared_port_note_appears_only_when_a_port_is_shared(self, snapshot: Snapshot):
+        topo = build_topology(snapshot)
+        assert "hidden switch" not in self._legend_text(topo, TREE)
+
+        assert "hidden switch" in self._legend_text(_topo_with_shared_port(), TREE)
 
 
 class TestApiKeyIsNotCarriedAcrossHosts:
@@ -697,6 +766,44 @@ class TestDrawioProvenanceMarker:
         xml = self._render(Provenance.TOPOLOGY_GRAPH, wireless=True)
         assert "endArrow=oval;endFill=0" in xml
         assert "dashed=1" in xml
+
+
+class TestDrawioSharedPortMarker:
+    """The draw.io twin of the DOT `* ` port-label marker: KAN-199."""
+
+    def _render(self, shared: bool):
+        from unifi_map.layout import Layout, Placed
+        from unifi_map.model import Edge, Kind, Node, Provenance, Topology
+        from unifi_map.render_drawio import render_drawio
+        from unifi_map.theme import LIGHT
+
+        topo = Topology()
+        topo.add(Node(id="sw", label="switch", kind=Kind.SWITCH))
+        topo.add(Node(id="c1", label="c1", kind=Kind.WIRED_CLIENT))
+        topo.edges.append(
+            Edge(src="c1", dst="sw", label="port 7", provenance=Provenance.CLIENT_UPLINK)
+        )
+        nodes = {
+            "sw": Placed(x=0.0, y=0.0, width=10.0, height=10.0),
+            "c1": Placed(x=0.0, y=20.0, width=10.0, height=10.0),
+        }
+        if shared:
+            topo.add(Node(id="c2", label="c2", kind=Kind.WIRED_CLIENT))
+            topo.edges.append(
+                Edge(src="c2", dst="sw", label="port 7", provenance=Provenance.CLIENT_UPLINK)
+            )
+            nodes["c2"] = Placed(x=20.0, y=20.0, width=10.0, height=10.0)
+        layout = Layout(nodes=nodes, width=30.0, height=30.0)
+        return render_drawio(topo, layout, "t", LIGHT)
+
+    def test_a_shared_port_gets_an_asterisk(self):
+        xml = self._render(shared=True)
+        assert xml.count("port 7 *") == 2
+
+    def test_an_unshared_port_gets_no_asterisk(self):
+        xml = self._render(shared=False)
+        assert "port 7" in xml
+        assert "port 7 *" not in xml
 
 
 class TestDrawioGeometryIsAddressable:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -118,6 +118,7 @@ def test_a_shared_port_gets_an_asterisk_on_both_edges():
     lines = [line for line in dot_source.splitlines() if '"n_sw" -> "n_c' in line]
     assert len(lines) == 2
     assert all('label="port 7 *"' in line for line in lines)
+    assert all("arrowhead=diamond" in line for line in lines)
 
 
 def test_an_unshared_port_gets_no_asterisk():
@@ -125,6 +126,22 @@ def test_an_unshared_port_gets_no_asterisk():
     line = next(line for line in dot_source.splitlines() if '"n_sw" -> "n_c1"' in line)
     assert 'label="port 7"' in line
     assert "*" not in line
+    assert "arrowhead=diamond" not in line
+
+
+def test_a_shared_port_still_shows_the_arrowhead_when_layout_unifi_hides_labels():
+    """`--layout unifi` is the default and suppresses port labels entirely
+
+    (ortho routing can't place them), which was found to silently erase the
+    `*` marker along with every other port label -- leaving the default,
+    most-used render with no visible signal at all. The arrowhead has to be
+    the layout-independent channel this signal survives on.
+    """
+    dot_source = render_dot(_topo_with_shared_port(), "t", UNIFI)
+    lines = [line for line in dot_source.splitlines() if '"n_sw" -> "n_c' in line]
+    assert len(lines) == 2
+    assert all("label=" not in line for line in lines), "unifi layout must not show port labels"
+    assert all("arrowhead=diamond" in line for line in lines)
 
 
 def test_mac_colons_are_stripped_from_dot_identifiers(snapshot: Snapshot):

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -337,6 +337,36 @@ class TestOverridesCheck:
         assert cmd_overrides(args) == 2
 
 
+class TestOverridesGenerate:
+    """KAN-120: `unifi-map overrides generate` prints a commented skeleton."""
+
+    def test_it_prints_a_commented_skeleton_to_stdout(self, capsys):
+        from unifi_map.cli import build_parser, cmd_overrides
+
+        args = build_parser().parse_args(["--cache-dir", "examples/demo", "overrides", "generate"])
+        assert cmd_overrides(args) == 0
+        out, _err = capsys.readouterr()
+        # The demo dataset ships an unplaceable client on purpose.
+        assert "[[link]]" in out
+        assert 'to = ""' in out
+        # Every candidate line is commented out, so the file is inert as-is.
+        for line in out.splitlines():
+            if line.strip():
+                assert line.startswith("#"), f"uncommented line in the skeleton: {line!r}"
+        # Log noise (artwork resolution) must not land in the printed file.
+        assert "Artwork" not in out
+
+    def test_no_overrides_file_is_needed(self, tmp_path, monkeypatch):
+        """Unlike `check`, `generate` never reads an overrides file at all, so
+        an empty directory with no overrides.toml anywhere near it is fine."""
+        from unifi_map.cli import build_parser, cmd_overrides
+
+        demo = (Path.cwd() / "examples" / "demo").resolve()
+        monkeypatch.chdir(tmp_path)
+        args = build_parser().parse_args(["--cache-dir", str(demo), "overrides", "generate"])
+        assert cmd_overrides(args) == 0
+
+
 class TestArtworkCountsSayWhatTheyMeasure:
     """`0 of 19` means something different with a cold cache than a warm one.
 

--- a/unifi-map.1
+++ b/unifi-map.1
@@ -50,7 +50,7 @@ Fetch then render (both stages; not all formats, see \-f)
 Describe the network's shape, for sharing in an issue
 .TP
 \fBoverrides\fR
-Check an overrides file without rendering
+Check an overrides file, or generate a skeleton, without rendering
 .SH GLOBAL OPTIONS
 Accepted before or after the subcommand, so
 \fBunifi\-map all \-\-support\-file\fR \fIF\fR and
@@ -167,14 +167,14 @@ With \-\-layout tree, stagger leaf nodes into rows of ~N to control aspect ratio
 Skip the consent prompt. Read what the report contains first; `unifi\-map shape` on its own prints that and asks.
 .SH OVERRIDES OPTIONS
 .TP
-\fBaction\fR \fI{check}\fR
-check: apply the file against the cached snapshot and report, failing on any selector that matches nothing or several things
+\fBaction\fR \fI{check,generate}\fR
+check: apply the file against the cached snapshot and report, failing on any selector that matches nothing or several things. generate: print a commented overrides skeleton, seeded from what the cached snapshot could not resolve, to stdout
 .TP
 \fB\-\-show\-offline\fR \fI{yes,no}\fR
 Include devices the controller lists but that are not currently connected. Defaults to no, because a controller keeps remembering hardware long after it has been pulled from the rack; use yes when you want to see what it still thinks exists (default: no)
 .TP
 \fB\-\-overrides\fR
-Which file to check. Defaults to overrides.toml when it exists.
+Which file to check. Defaults to overrides.toml when it exists. Not used by generate.
 .SH ENVIRONMENT
 .TP
 \fBUNIFI_HOST\fR


### PR DESCRIPTION
## What this changes

Five commits, building on each other:

- **Flag switch ports shared by several wired clients (KAN-199).** Several wired clients reporting the same switch and port usually means an unmanaged switch or a virtualisation host the controller cannot see, and needs no cooperation from the hidden device to detect, unlike LLDP. Surfaced four ways from one `Topology.shared_ports()`: a marker on the diagram, a named `SHARED SWITCH PORTS` section in `--report`, a console warning (obfuscation-aware), and never as a synthetic node — which of the two causes it is can't be told apart from here, so nothing is invented either way.
- **Fix the marker being invisible in the default render.** The `*` port-label marker rode on `Style.show_port_labels`, which `--layout unifi` (the default) turns off entirely. Gave the edge its own layout-independent channel (`arrowhead=diamond`, unconditional, the same approach `TOPOLOGY_GRAPH`'s `arrowhead=odot` already used) so the signal survives the render most people actually produce.
- **Add `unifi-map overrides generate` (KAN-120).** Prints a commented `overrides.toml` skeleton to stdout, seeded from the same three signals `--report` names: unplaced clients, shared switch ports, and ambiguous artwork matches. Every block is commented out, so the file is a no-op until edited; the one thing it never fills in is a client's real uplink.
- **Documentation sweep** for both features: `CHANGELOG.md` Unreleased entries, `docs/usage.md`'s diagram-reading table and `--report` walkthrough, a new "Generating a starting point" section in `docs/overrides.md`, and `TODO.md`/`CLAUDE.md` reconciled against what actually shipped.
- **Escape controller-supplied text in the generated TOML.** Found by external review: a label containing `"` produced invalid TOML the moment a block was uncommented, and a label containing a newline would have broken out of its `#` comment entirely — a real break of "inert until edited", not a cosmetic one. Fixed with two small encoders, applied to every label and id reaching the output.

## Checklist

- [x] `make check` passes (`ruff format --check`, `ruff check`, `pytest`), and I
      checked its exit code rather than eyeballing piped output
- [x] Tests added or updated, and none of them touch the network
- [x] Any new fixture data is non-identifying: no real hostnames, subnets, SSIDs
      or device addresses
- [x] No Ubiquiti artwork vendored into the repository
- [x] No `cache/` or `out/` contents committed
- [x] If this changes what gets drawn, the legend and the docs still describe
      it accurately (`docs/usage.md` for layouts and reading the diagram,
      `docs/output.md` for formats)

## Anything you are unsure about

KAN-199's other signal — reading the controller's own `has_unknown_switch` boolean from the v2 topology payload — is still unbuilt and still unverified (per-site behaviour, whether it clears, whether an all-UniFi network ever sets it). Documented as open in `TODO.md`/`CLAUDE.md` rather than attempted here, since it would be guessing.

Every guard in this PR was mutation-tested: reverted, confirmed the new/changed tests fail red, restored.